### PR TITLE
Fix issue when requiring float in the DTO.

### DIFF
--- a/src/Property.php
+++ b/src/Property.php
@@ -12,6 +12,7 @@ class Property extends ReflectionProperty
     protected static $typeMapping = [
         'int' => 'integer',
         'bool' => 'boolean',
+        'float' => 'double',
     ];
 
     /** @var \Spatie\DataTransferObject\DataTransferObject */

--- a/tests/DataTransferTransferObjectTest.php
+++ b/tests/DataTransferTransferObjectTest.php
@@ -163,6 +163,17 @@ class DataTransferObjectTest extends TestCase
     }
 
     /** @test */
+    public function float_is_supported()
+    {
+        new class(['foo' => 5.1]) extends DataTransferObject {
+            /** @var float */
+            public $foo;
+        };
+
+        $this->markTestSucceeded();
+    }
+
+    /** @test */
     public function classes_are_supported()
     {
         new class(['foo' => new DummyClass()]) extends DataTransferObject {


### PR DESCRIPTION
PHP's `gettype()` returns "double" for float, causing an exception to be thrown for valid floats with something like:

> Invalid type: expected ExampleDto::floatVariable to be of type float, instead got value `5.1`.

Example class:

```php
class ExampleDto extends DataTransferObject
{
    /** @var float */
    public $floatVariable;
}
```

This change fixes the issue by providing a mapping from "double" to "float".