### PR TITLE
Adds automatic casting of DTO arrays.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `data-transfer-object` will be documented in this file
 
+## 1.7.0 - 2019-01-31
+
+- Nested array DTO casting supported.
+
 ## 1.6.6 - 2018-12-04
 
 - Properly support `float`.

--- a/README.md
+++ b/README.md
@@ -229,6 +229,35 @@ $postData = new PostData([
 ]);
 ```
 
+### Automatic casting of nested array DTOs
+
+Similarly to above, nested array DTOs will automatically be casted.
+
+```php
+class TagData extends DataTransferObject
+{
+    /** @var string */
+   public $name;
+}
+
+class PostData extends DataTransferObject
+{
+    /** @var \TagData[] */
+   public $tags;
+}
+```
+
+`PostData` will automatically construct tags like such:
+
+```php
+$postData = new PostData([
+    'tags' => [
+        ['name' => 'foo'],
+        ['name' => 'bar']
+    ]
+]);
+```
+
 ### A note on immutability
 
 These data transfer objects are meant to be only constructed once, and not changed thereafter.

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -60,11 +60,4 @@ class Arr
 
         return array_key_exists($key, $array);
     }
-
-    public static function isAssoc(array $arr): bool
-    {
-        $stringKeys = array_filter(array_keys($arr), 'is_string');
-
-        return count($stringKeys) > 0;
-    }
 }

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -60,4 +60,11 @@ class Arr
 
         return array_key_exists($key, $array);
     }
+
+    public static function isAssoc(array $arr): bool
+    {
+        $stringKeys = array_filter(array_keys($arr), 'is_string');
+
+        return count($stringKeys) > 0;
+    }
 }

--- a/src/Property.php
+++ b/src/Property.php
@@ -176,7 +176,11 @@ class Property extends ReflectionProperty
 
     protected function shouldBeCastToCollection(array $values): bool
     {
-        foreach ($values as $value) {
+        foreach ($values as $key => $value) {
+            if (is_string($key)) {
+                return false;
+            }
+
             if (! is_array($value)) {
                 return false;
             }

--- a/tests/DataTransferTransferObjectTest.php
+++ b/tests/DataTransferTransferObjectTest.php
@@ -340,12 +340,11 @@ class DataTransferObjectTest extends TestCase
     /** @test */
     public function nested_array_dtos_cannot_cast_with_null()
     {
-        $object = new NestedParentOfMany([
+        $this->expectException(DataTransferObjectError::class);
+
+        new NestedParentOfMany([
             'name' => 'parent',
         ]);
-
-        $this->assertNotEquals(null, $object->children);
-        $this->assertEmpty($object->children);
     }
 
     /** @test */

--- a/tests/DataTransferTransferObjectTest.php
+++ b/tests/DataTransferTransferObjectTest.php
@@ -340,11 +340,22 @@ class DataTransferObjectTest extends TestCase
     /** @test */
     public function nested_array_dtos_cannot_cast_with_null()
     {
-        $this->expectException(DataTransferObjectError::class);
-
-        new NestedParentOfMany([
+        $object = new NestedParentOfMany([
             'name' => 'parent',
-            'children' => null,
         ]);
+
+        $this->assertNotEquals(null, $object->children);
+        $this->assertEmpty($object->children);
+    }
+
+    /** @test */
+    public function nested_array_dtos_can_be_nullable()
+    {
+        $object = new class(['children' => null]) extends DataTransferObject {
+            /** @var Spatie\DataTransferObject\Tests\TestClasses\NestedChild[]|null */
+            public $children;
+        };
+
+        $this->assertNull($object->children);
     }
 }

--- a/tests/DataTransferTransferObjectTest.php
+++ b/tests/DataTransferTransferObjectTest.php
@@ -10,6 +10,7 @@ use Spatie\DataTransferObject\Tests\TestClasses\DummyClass;
 use Spatie\DataTransferObject\Tests\TestClasses\OtherClass;
 use Spatie\DataTransferObject\Tests\TestClasses\NestedChild;
 use Spatie\DataTransferObject\Tests\TestClasses\NestedParent;
+use Spatie\DataTransferObject\Tests\TestClasses\NestedParentOfMany;
 
 class DataTransferObjectTest extends TestCase
 {
@@ -294,5 +295,56 @@ class DataTransferObjectTest extends TestCase
         };
 
         $this->assertEquals(['name' => 'child'], $valueObject->toArray()['childs'][0]);
+    }
+
+    /** @test */
+    public function nested_array_dtos_are_automatically_cast_to_arrays_of_dtos()
+    {
+        $data = [
+            'name' => 'parent',
+            'children' => [
+                ['name' => 'child'],
+            ],
+        ];
+
+        $object = new NestedParentOfMany($data);
+
+        $this->assertNotEmpty($object->children);
+        $this->assertInstanceOf(NestedChild::class, $object->children[0]);
+        $this->assertEquals('parent', $object->name);
+        $this->assertEquals('child', $object->children[0]->name);
+    }
+
+    /** @test */
+    public function nested_array_dtos_are_recursive_cast_to_arrays_of_dtos()
+    {
+        $data = [
+            'children' => [
+                [
+                    'name' => 'child',
+                    'children' => [
+                        ['name' => 'grandchild'],
+                    ],
+                ],
+            ],
+        ];
+
+        $object = new class($data) extends DataTransferObject {
+            /** @var \Spatie\DataTransferObject\Tests\TestClasses\NestedParentOfMany[] */
+            public $children;
+        };
+
+        $this->assertEquals(['name' => 'grandchild'], $object->toArray()['children'][0]['children'][0]);
+    }
+
+    /** @test */
+    public function nested_array_dtos_cannot_cast_with_null()
+    {
+        $this->expectException(DataTransferObjectError::class);
+
+        new NestedParentOfMany([
+            'name' => 'parent',
+            'children' => null,
+        ]);
     }
 }

--- a/tests/TestClasses/NestedParentOfMany.php
+++ b/tests/TestClasses/NestedParentOfMany.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests\TestClasses;
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class NestedParentOfMany extends DataTransferObject
+{
+    /** @var \Spatie\DataTransferObject\Tests\TestClasses\NestedChild[] */
+    public $children = [];
+
+    /** @var string */
+    public $name;
+}

--- a/tests/TestClasses/NestedParentOfMany.php
+++ b/tests/TestClasses/NestedParentOfMany.php
@@ -9,7 +9,7 @@ use Spatie\DataTransferObject\DataTransferObject;
 class NestedParentOfMany extends DataTransferObject
 {
     /** @var \Spatie\DataTransferObject\Tests\TestClasses\NestedChild[] */
-    public $children = [];
+    public $children;
 
     /** @var string */
     public $name;


### PR DESCRIPTION
This resolves #44.

This commit adds support for automatically casting of arrays to arrays of DTOs. Example from the update README:

```php
class TagData extends DataTransferObject
{
    /** @var string */
   public $name;
}

class PostData extends DataTransferObject
{
    /** @var \TagData[] */
   public $tags;
}
```

`PostData` will automatically construct tags like such:

```php
$postData = new PostData([
    'tags' => [
        ['name' => 'foo'],
        ['name' => 'bar']
    ]
]);
```