### PR TITLE
Fixes #47 - Allowing empty DTO's to be cast via empty arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `data-transfer-object` will be documented in this file
 
+## 1.7.1 - 2019-02-11
+
+- Fixes #47, allowing empty dto's to be cast to using an empty array.
+
 ## 1.7.0 - 2019-02-04
 
 - Nested array DTO casting supported.

--- a/src/Property.php
+++ b/src/Property.php
@@ -176,6 +176,10 @@ class Property extends ReflectionProperty
 
     protected function shouldBeCastToCollection(array $values): bool
     {
+        if (empty($values)) {
+            return false;
+        }
+
         foreach ($values as $key => $value) {
             if (is_string($key)) {
                 return false;

--- a/tests/DataTransferTransferObjectTest.php
+++ b/tests/DataTransferTransferObjectTest.php
@@ -7,6 +7,7 @@ namespace Spatie\DataTransferObject\Tests;
 use Spatie\DataTransferObject\DataTransferObject;
 use Spatie\DataTransferObject\DataTransferObjectError;
 use Spatie\DataTransferObject\Tests\TestClasses\DummyClass;
+use Spatie\DataTransferObject\Tests\TestClasses\EmptyChild;
 use Spatie\DataTransferObject\Tests\TestClasses\OtherClass;
 use Spatie\DataTransferObject\Tests\TestClasses\NestedChild;
 use Spatie\DataTransferObject\Tests\TestClasses\NestedParent;
@@ -356,5 +357,16 @@ class DataTransferObjectTest extends TestCase
         };
 
         $this->assertNull($object->children);
+    }
+
+    /** @test */
+    public function empty_dto_objects_can_be_cast_using_arrays()
+    {
+        $object = new class(['child' => []]) extends DataTransferObject {
+            /** @var \Spatie\DataTransferObject\Tests\TestClasses\EmptyChild */
+            public $child;
+        };
+
+        $this->assertInstanceOf(EmptyChild::class, $object->child);
     }
 }

--- a/tests/TestClasses/EmptyChild.php
+++ b/tests/TestClasses/EmptyChild.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests\TestClasses;
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class EmptyChild extends DataTransferObject
+{
+}


### PR DESCRIPTION
This adds a new `EmptyChild` DTO test class and associated test to resolve #47. Empty DTO's can be cast to using an empty array now.