### PR TITLE
Immutable data transfer objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `data-transfer-object` will be documented in this file
 
+## 1.8.0 - 2019-03-??
+
+- Support immutability
+
 ## 1.7.1 - 2019-02-11
 
 - Fixes #47, allowing empty dto's to be cast to using an empty array.

--- a/README.md
+++ b/README.md
@@ -259,10 +259,20 @@ $postData = new PostData([
 ```
 **Attention**: For nested type casting to work your Docblock definition needs to be a Fully Qualified Class Name (`\App\DTOs\TagData[]` instead of `TagData[]` and an use statement at the top)
 
-### A note on immutability
+### Immutability
 
-These data transfer objects are meant to be only constructed once, and not changed thereafter.
-You should never write data to the properties once the data transfer object is created, even though technically it's possible.
+If you want your data object to be never changeable (this is a good idea in some cases), you can make them immutable:
+
+```php
+$postData = PostData::immutable([
+    'tags' => [
+        ['name' => 'foo'],
+        ['name' => 'bar']
+    ]
+]);
+```
+
+Trying to change a property of `$postData` after it's constructed, will result in a `DataTransferObjectError`.
 
 ### Helper functions
 

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -15,6 +15,16 @@ abstract class DataTransferObject
     /** @var array */
     protected $onlyKeys = [];
 
+    /**
+     * @param array $parameters
+     *
+     * @return \Spatie\DataTransferObject\ImmutableDataTransferObject|static
+     */
+    public static function immutable(array $parameters): ImmutableDataTransferObject
+    {
+        return new ImmutableDataTransferObject(new static($parameters));
+    }
+
     public function __construct(array $parameters)
     {
         $class = new ReflectionClass(static::class);

--- a/src/DataTransferObjectError.php
+++ b/src/DataTransferObjectError.php
@@ -38,4 +38,9 @@ class DataTransferObjectError extends TypeError
     {
         return new self("Non-nullable property {$property->getFqn()} has not been initialized.");
     }
+
+    public static function immutable(string $property): DataTransferObjectError
+    {
+        return new self("Cannot change the value of property {$property} on an immutable data transfer object");
+    }
 }

--- a/src/ImmutableDataTransferObject.php
+++ b/src/ImmutableDataTransferObject.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Spatie\DataTransferObject;
+
+class ImmutableDataTransferObject
+{
+    /** @var \Spatie\DataTransferObject\DataTransferObject */
+    protected $dataTransferObject;
+
+    public function __construct(DataTransferObject $dataTransferObject)
+    {
+        $this->dataTransferObject = $dataTransferObject;
+    }
+
+    public function __set($name, $value)
+    {
+        throw DataTransferObjectError::immutable($name);
+    }
+
+    public function __get($name)
+    {
+        return $this->dataTransferObject->{$name};
+    }
+
+    public function __call($name, $arguments)
+    {
+        return call_user_func_array([$this->dataTransferObject, $name], $arguments);
+    }
+}

--- a/tests/ImmutableTest.php
+++ b/tests/ImmutableTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests;
+
+use Spatie\DataTransferObject\DataTransferObjectError;
+use Spatie\DataTransferObject\Tests\TestClasses\TestDataTransferObject;
+
+class ImmutableTest extends TestCase
+{
+    /** @test */
+    public function it()
+    {
+        $dto = TestDataTransferObject::immutable([
+            'testProperty' => 1
+        ]);
+
+        $this->assertEquals(1, $dto->testProperty);
+
+        $this->expectException(DataTransferObjectError::class);
+
+        $dto->testProperty = 2;
+    }
+}

--- a/tests/ImmutableTest.php
+++ b/tests/ImmutableTest.php
@@ -8,7 +8,7 @@ use Spatie\DataTransferObject\Tests\TestClasses\TestDataTransferObject;
 class ImmutableTest extends TestCase
 {
     /** @test */
-    public function it()
+    public function immutable_values_cannot_be_overwritten()
     {
         $dto = TestDataTransferObject::immutable([
             'testProperty' => 1
@@ -19,5 +19,15 @@ class ImmutableTest extends TestCase
         $this->expectException(DataTransferObjectError::class);
 
         $dto->testProperty = 2;
+    }
+
+    /** @test */
+    public function method_calls_are_proxied()
+    {
+        $dto = TestDataTransferObject::immutable([
+            'testProperty' => 1
+        ]);
+
+        $this->assertEquals(['testProperty' => 1], $dto->toArray());
     }
 }


### PR DESCRIPTION
By using `ImmutableDataTransferObject` as a proxy, we're able to have the best of both worlds!

closes #12 