### PR TITLE
Changed casted to cast in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ class PostCollection extends DataTransferObjectCollection
 
 ### Automatic casting of nested DTOs
 
-If you've got nested DTO fields, data passed to the parent DTO will automatically be casted.
+If you've got nested DTO fields, data passed to the parent DTO will automatically be cast.
 
 ```php
 class PostData extends DataTransferObject
@@ -231,7 +231,7 @@ $postData = new PostData([
 
 ### Automatic casting of nested array DTOs
 
-Similarly to above, nested array DTOs will automatically be casted.
+Similarly to above, nested array DTOs will automatically be cast.
 
 ```php
 class TagData extends DataTransferObject


### PR DESCRIPTION
From https://writingexplained.org/cast-vs-casted:

> Casted is an incorrect past tense conjugation of the verb cast. It almost never appears in print or edited works of any kind.

Example of past tense from https://laravel.com/docs/6.x/eloquent-mutators#attribute-casting:

> Now the `is_admin` attribute will always be **cast** to a boolean when you access it...