### PR TITLE
Support for iterable type

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ class PostData extends DataTransferObject
     public $property;
     
     /**
+     * Iterator of types: 
+     *
+     * @var iterator<\App\Models\Author>
+     */
+    public $property;
+    
+    /**
      * Union types: 
      *
      * @var string|int
@@ -148,6 +155,13 @@ class PostData extends DataTransferObject
      * Mixed types: 
      *
      * @var mixed|null
+     */
+    public $property;
+    
+    /**
+     * Any iterator : 
+     *
+     * @var iterator
      */
     public $property;
     


### PR DESCRIPTION
This PR aims to support iterable types. see #70 

It can be used with simple iterable type : 
```php
/** @var iterable */
public $items
```
but also with types
```php
/** @var iterable<string> */
public $strings
```
or with DTOs
```php
/** @var iterable<\App\DTO\NestedDto> */
public $nested
```

I would be happy to push further or add extra tests if needed

