### PR TITLE
PoC to automatically cast DateTime et al property

### DIFF
--- a/src/Property.php
+++ b/src/Property.php
@@ -8,6 +8,14 @@ use ReflectionProperty;
 
 class Property extends ReflectionProperty
 {
+    /**
+     * - The key is the type of the propoerty
+     * - The callable receives the value and may return the same or a different one.
+     * @var array<string,callable(mixed)>
+     */
+    public static $make = [
+    ];
+
     /** @var array */
     protected static $typeMapping = [
         'int' => 'integer',
@@ -51,6 +59,8 @@ class Property extends ReflectionProperty
     {
         if (is_array($value)) {
             $value = $this->shouldBeCastToCollection($value) ? $this->castCollection($value) : $this->cast($value);
+        } else {
+            $value = $this->makeValue($value);
         }
 
         if (! $this->isValidType($value)) {
@@ -248,5 +258,20 @@ class Property extends ReflectionProperty
         }
 
         return true;
+    }
+
+    protected function makeValue($value)
+    {
+        foreach ($this->types as $type) {
+            $type = ltrim($type, '\\');
+
+            if (! isset($this::$make[$type])) {
+                continue;
+            }
+
+            return $this::$make[$type]($value);
+        }
+
+        return $value;
     }
 }

--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Spatie\DataTransferObject\Tests;
 
 use ArrayIterator;
+use DateTime;
 use Spatie\DataTransferObject\DataTransferObject;
 use Spatie\DataTransferObject\DataTransferObjectError;
+use Spatie\DataTransferObject\Property;
+use Spatie\DataTransferObject\Tests\TestClasses\DateTimeProperty;
 use Spatie\DataTransferObject\Tests\TestClasses\DummyClass;
 use Spatie\DataTransferObject\Tests\TestClasses\EmptyChild;
 use Spatie\DataTransferObject\Tests\TestClasses\NestedChild;
@@ -16,6 +19,13 @@ use Spatie\DataTransferObject\Tests\TestClasses\OtherClass;
 
 class DataTransferObjectTest extends TestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+
+        Property::$make = [];
+    }
+
     /** @test */
     public function only_the_type_hinted_type_may_be_passed()
     {
@@ -442,5 +452,24 @@ class DataTransferObjectTest extends TestCase
         $this->assertContainsOnly(NestedChild::class, $object->children);
         $this->assertEquals('Alice', $object->children[0]->name);
         $this->assertEquals('Bob', $object->children[1]->name);
+    }
+
+    /** @test */
+    public function can_make_datetime()
+    {
+        Property::$make[DateTime::class] = function ($value) {
+            return new DateTime($value);
+        };
+
+        $expectedDate = '2020-10-10T12:13:14+12:34';
+
+        $data = [
+            'date' => $expectedDate,
+        ];
+
+        $object = new DateTimeProperty($data);
+
+        $this->assertInstanceOf(DateTime::class, $object->date);
+        $this->assertSame($expectedDate, $object->date->format(DateTime::ATOM));
     }
 }

--- a/tests/TestClasses/DateTimeProperty.php
+++ b/tests/TestClasses/DateTimeProperty.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests\TestClasses;
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class DateTimeProperty extends DataTransferObject
+{
+    /** @var \DateTime */
+    public $date;
+}


### PR DESCRIPTION
Since JSON has no dedicated date time type, all we get a string. The current best practice is to simply manually perform this, see https://github.com/spatie/data-transfer-object/issues/34#issuecomment-436909305 for an example
> ```php
> created_at' => Carbon::make($data['created_timestamp']),
> ```

But if there are a) many fields and b) they're in nested parts, this gets tedious quickly.

With this PoC we can set a static list of "makers" on `Property::$make` => the closure receives the $value and can "make" it whatever it needs:
```php
        Property::$make[DateTime::class] = function ($value) {
            return new DateTime($value);
        };
```
and then in the DTO:
```php
class Mydto extends DataTransferObject {
  /** @var \DateTime */
  property $date;
}
````
The reason for basically supporting arbitrary makers is that, although I've given the example with DateTime, which is ubiquitous, I might was well rather want a Carbon or Chronos object instead.

I didn't invest too much to come up with a perfect design, I was rather interested what a MVP would look like and what others thing about the idea how it could or could not go from here.

It is my understanding that this library is not concerned with:
- transformation of data
- casting of discrete values

and rightly so.

However in the pragmatic use cases I've seen, supporting date time is really a very useful property.