### PR TITLE
Improve extendability of DataTransferObject

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -48,9 +48,7 @@ abstract class DataTransferObject
 
             $value = $parameters[$field] ?? $this->{$field} ?? null;
 
-            if (is_array($value)) {
-                $value = $valueCaster->cast($value, $validator);
-            }
+            $value = $this->castValue($valueCaster, $validator, $value);
 
             if (! $validator->isValidType($value)) {
                 throw DataTransferObjectError::invalidType(
@@ -169,5 +167,20 @@ abstract class DataTransferObject
 
             return $properties;
         });
+    }
+
+    /**
+     * @param \Spatie\DataTransferObject\ValueCaster $valueCaster
+     * @param \Spatie\DataTransferObject\FieldValidator $fieldValidator
+     * @param mixed $value
+     * @return mixed
+     */
+    protected function castValue(ValueCaster $valueCaster, FieldValidator $fieldValidator, $value)
+    {
+        if (is_array($value)) {
+            return $valueCaster->cast($value, $fieldValidator);
+        }
+
+        return $value;
     }
 }

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -152,7 +152,7 @@ abstract class DataTransferObject
      *
      * @return \Spatie\DataTransferObject\FieldValidator[]
      */
-    private function getFieldValidators(): array
+    protected function getFieldValidators(): array
     {
         return DTOCache::resolve(static::class, function () {
             $class = new ReflectionClass(static::class);

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -32,7 +32,7 @@ abstract class DataTransferObject
     {
         $validators = $this->getFieldValidators();
 
-        $valueCaster = new ValueCaster();
+        $valueCaster = $this->getValueCaster();
 
         foreach ($validators as $field => $validator) {
             if (
@@ -182,5 +182,10 @@ abstract class DataTransferObject
         }
 
         return $value;
+    }
+
+    protected function getValueCaster(): ValueCaster
+    {
+        return new ValueCaster();
     }
 }


### PR DESCRIPTION
My previous PR https://github.com/spatie/data-transfer-object/pull/76 wasn't deemed in the scope of the library => fair point 👍 

Still I would like the ability to use the feature outlined in the PR in my own project.

As it stands right now, I've to override the whole constructor, slightly adjust it and make a copy of `getFieldValidators`.

With these changes, I'm able to simple override these methods and provide my own logic:
- allow returning my own ValueCaster instead of hardcoding `new ValueCaster` in the constructor
- ability to control the casting by overriding `castValue`
- change visibility of `getFieldValidators` from private to protected
  Otherwise someone who might want to use a custom constructor couldn't use the cache "as is"

Thanks!