### PR TITLE
DataTransferObjectError::invalidType : get actual type before mutating $value for the error message

### DIFF
--- a/src/DataTransferObjectError.php
+++ b/src/DataTransferObjectError.php
@@ -21,6 +21,8 @@ class DataTransferObjectError extends TypeError
         array $expectedTypes,
         $value
     ): DataTransferObjectError {
+        $currentType = gettype($value);
+
         if ($value === null) {
             $value = 'null';
         }
@@ -34,8 +36,6 @@ class DataTransferObjectError extends TypeError
         }
 
         $expectedTypes = implode(', ', $expectedTypes);
-
-        $currentType = gettype($value);
 
         return new self("Invalid type: expected `{$class}::{$field}` to be of type `{$expectedTypes}`, instead got value `{$value}`, which is {$currentType}.");
     }

--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -80,7 +80,7 @@ class DataTransferObjectTest extends TestCase
     public function null_is_allowed_only_if_explicitly_specified()
     {
         $this->expectException(DataTransferObjectError::class);
-        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `string`, instead got value `null`, which is string/');
+        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `string`, instead got value `null`, which is NULL/');
 
         new class(['foo' => null]) extends DataTransferObject {
             /** @var string */
@@ -190,7 +190,7 @@ class DataTransferObjectTest extends TestCase
         $this->markTestSucceeded();
 
         $this->expectException(DataTransferObjectError::class);
-        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `\\\Spatie\\\DataTransferObject\\\Tests\\\TestClasses\\\DummyClass`, instead got value `class@anonymous[^`]+`, which is string/');
+        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `\\\Spatie\\\DataTransferObject\\\Tests\\\TestClasses\\\DummyClass`, instead got value `class@anonymous[^`]+`, which is object/');
 
         new class(['foo' => new class() {
         },
@@ -212,7 +212,7 @@ class DataTransferObjectTest extends TestCase
         $this->markTestSucceeded();
 
         $this->expectException(DataTransferObjectError::class);
-        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `\\\Spatie\\\DataTransferObject\\\Tests\\\TestClasses\\\DummyClass\[\]`, instead got value `array`, which is string/');
+        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `\\\Spatie\\\DataTransferObject\\\Tests\\\TestClasses\\\DummyClass\[\]`, instead got value `array`, which is array/');
 
         new class(['foo' => [new OtherClass()]]) extends DataTransferObject {
             /** @var \Spatie\DataTransferObject\Tests\TestClasses\DummyClass[] */
@@ -224,7 +224,7 @@ class DataTransferObjectTest extends TestCase
     public function an_exception_is_thrown_for_a_generic_collection_of_null()
     {
         $this->expectException(DataTransferObjectError::class);
-        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `string\[\]`, instead got value `array`, which is string./');
+        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `string\[\]`, instead got value `array`, which is array./');
 
         new class(['foo' => [null]]) extends DataTransferObject {
             /** @var string[] */
@@ -236,7 +236,7 @@ class DataTransferObjectTest extends TestCase
     public function an_exception_is_thrown_when_property_was_not_initialised()
     {
         $this->expectException(DataTransferObjectError::class);
-        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `string`, instead got value `null`, which is string/');
+        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `string`, instead got value `null`, which is NULL/');
 
         new class([]) extends DataTransferObject {
             /** @var string */
@@ -350,7 +350,7 @@ class DataTransferObjectTest extends TestCase
     public function nested_array_dtos_cannot_cast_with_null()
     {
         $this->expectException(DataTransferObjectError::class);
-        $this->expectExceptionMessage('Invalid type: expected `Spatie\DataTransferObject\Tests\TestClasses\NestedParentOfMany::children` to be of type `\Spatie\DataTransferObject\Tests\TestClasses\NestedChild[]`, instead got value `null`, which is string.');
+        $this->expectExceptionMessage('Invalid type: expected `Spatie\DataTransferObject\Tests\TestClasses\NestedParentOfMany::children` to be of type `\Spatie\DataTransferObject\Tests\TestClasses\NestedChild[]`, instead got value `null`, which is NULL.');
 
         new NestedParentOfMany([
             'name' => 'parent',
@@ -423,7 +423,7 @@ class DataTransferObjectTest extends TestCase
     public function an_exception_is_thrown_for_incoherent_iterator_type()
     {
         $this->expectException(DataTransferObjectError::class);
-        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::strings` to be of type `iterable<string>`, instead got value `array`, which is string./');
+        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::strings` to be of type `iterable<string>`, instead got value `array`, which is array./');
 
         new class(['strings' => ['foo', 1]]) extends DataTransferObject {
             /** @var iterable<string> */

--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -27,6 +27,7 @@ class DataTransferObjectTest extends TestCase
         $this->markTestSucceeded();
 
         $this->expectException(DataTransferObjectError::class);
+        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `string`, instead got value ``, which is boolean/');
 
         new class(['foo' => false]) extends DataTransferObject {
             /** @var string */
@@ -79,6 +80,7 @@ class DataTransferObjectTest extends TestCase
     public function null_is_allowed_only_if_explicitly_specified()
     {
         $this->expectException(DataTransferObjectError::class);
+        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `string`, instead got value `null`, which is string/');
 
         new class(['foo' => null]) extends DataTransferObject {
             /** @var string */
@@ -90,6 +92,7 @@ class DataTransferObjectTest extends TestCase
     public function unknown_properties_throw_an_error()
     {
         $this->expectException(DataTransferObjectError::class);
+        $this->expectExceptionMessageRegExp('/Public properties `bar` not found on class@anonymous/');
 
         new class(['bar' => null]) extends DataTransferObject {
         };
@@ -187,6 +190,7 @@ class DataTransferObjectTest extends TestCase
         $this->markTestSucceeded();
 
         $this->expectException(DataTransferObjectError::class);
+        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `\\\Spatie\\\DataTransferObject\\\Tests\\\TestClasses\\\DummyClass`, instead got value `class@anonymous[^`]+`, which is string/');
 
         new class(['foo' => new class() {
         },
@@ -208,6 +212,7 @@ class DataTransferObjectTest extends TestCase
         $this->markTestSucceeded();
 
         $this->expectException(DataTransferObjectError::class);
+        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `\\\Spatie\\\DataTransferObject\\\Tests\\\TestClasses\\\DummyClass\[\]`, instead got value `array`, which is string/');
 
         new class(['foo' => [new OtherClass()]]) extends DataTransferObject {
             /** @var \Spatie\DataTransferObject\Tests\TestClasses\DummyClass[] */
@@ -219,6 +224,7 @@ class DataTransferObjectTest extends TestCase
     public function an_exception_is_thrown_for_a_generic_collection_of_null()
     {
         $this->expectException(DataTransferObjectError::class);
+        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `string\[\]`, instead got value `array`, which is string./');
 
         new class(['foo' => [null]]) extends DataTransferObject {
             /** @var string[] */
@@ -230,6 +236,7 @@ class DataTransferObjectTest extends TestCase
     public function an_exception_is_thrown_when_property_was_not_initialised()
     {
         $this->expectException(DataTransferObjectError::class);
+        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `string`, instead got value `null`, which is string/');
 
         new class([]) extends DataTransferObject {
             /** @var string */
@@ -343,6 +350,7 @@ class DataTransferObjectTest extends TestCase
     public function nested_array_dtos_cannot_cast_with_null()
     {
         $this->expectException(DataTransferObjectError::class);
+        $this->expectExceptionMessage('Invalid type: expected `Spatie\DataTransferObject\Tests\TestClasses\NestedParentOfMany::children` to be of type `\Spatie\DataTransferObject\Tests\TestClasses\NestedChild[]`, instead got value `null`, which is string.');
 
         new NestedParentOfMany([
             'name' => 'parent',
@@ -415,6 +423,7 @@ class DataTransferObjectTest extends TestCase
     public function an_exception_is_thrown_for_incoherent_iterator_type()
     {
         $this->expectException(DataTransferObjectError::class);
+        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::strings` to be of type `iterable<string>`, instead got value `array`, which is string./');
 
         new class(['strings' => ['foo', 1]]) extends DataTransferObject {
             /** @var iterable<string> */

--- a/tests/ImmutableTest.php
+++ b/tests/ImmutableTest.php
@@ -18,6 +18,7 @@ class ImmutableTest extends TestCase
         $this->assertEquals(1, $dto->testProperty);
 
         $this->expectException(DataTransferObjectError::class);
+        $this->expectExceptionMessage('Cannot change the value of property testProperty on an immutable data transfer object');
 
         $dto->testProperty = 2;
     }


### PR DESCRIPTION
I believe this is an error and wasn't caught so far because no tests for the actual message did exist.

In `\Spatie\DataTransferObject\DataTransferObjectError::invalidType` this code was executed:
```php
        $currentType = gettype($value);
```
but it was done so _after_ `$value` was possible overwritten like this:
```php
        if ($value === null) {
            $value = 'null';
        }

        if (is_object($value)) {
            $value = get_class($value);
        }

        if (is_array($value)) {
            $value = 'array';
        }
```
Which basically made `gettype($value);` to yield `string` in the majority of cases.

This PR fixes this.
Please also see the 2nd commit stand-alone, showing the change form the old to the new message  => https://github.com/spatie/data-transfer-object/commit/182c9251e5fb78e6a7c53d5c7f48a72a5537017e