### PR TITLE
[DTO] Ignore static public properties

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -162,6 +162,11 @@ abstract class DataTransferObject
             $properties = [];
 
             foreach ($class->getProperties(ReflectionProperty::IS_PUBLIC) as $reflectionProperty) {
+                // Skip static properties
+                if ($reflectionProperty->isStatic()) {
+                    continue;
+                }
+
                 $field = $reflectionProperty->getName();
 
                 $properties[$field] = FieldValidator::fromReflection($reflectionProperty);

--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -443,4 +443,16 @@ class DataTransferObjectTest extends TestCase
         $this->assertEquals('Alice', $object->children[0]->name);
         $this->assertEquals('Bob', $object->children[1]->name);
     }
+
+    /** @test */
+    public function ignore_static_public_properties()
+    {
+        $object = new class(['foo' => 'bar']) extends DataTransferObject {
+            /** @var string */
+            public $foo;
+            public static $prop;
+        };
+
+        $this->assertSame('bar', $object->foo);
+    }
 }


### PR DESCRIPTION
I've a project where I need to use a public static property on a DTO but
it clashes because the code doesn't ignore it. But it should, as they're
not relevant for the data encapsulation of the DTO.