### PR TITLE
[DTO] Ignore static properties also when serializing

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -93,6 +93,11 @@ abstract class DataTransferObject
         $properties = $class->getProperties(ReflectionProperty::IS_PUBLIC);
 
         foreach ($properties as $reflectionProperty) {
+            // Skip static properties
+            if ($reflectionProperty->isStatic()) {
+                continue;
+            }
+
             $data[$reflectionProperty->getName()] = $reflectionProperty->getValue($this);
         }
 

--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -485,4 +485,20 @@ class DataTransferObjectTest extends TestCase
 
         $this->assertSame('bar', $object->foo);
     }
+
+    /** @test */
+    public function ignore_static_public_properties_when_serializing()
+    {
+        $object = new class(['foo' => 'bar']) extends DataTransferObject {
+            /** @var string */
+            public $foo;
+            public static $prop;
+        };
+
+        $expected = [
+            'foo' => 'bar',
+        ];
+
+        $this->assertSame($expected, $object->all());
+    }
 }


### PR DESCRIPTION
The previous fix in https://github.com/spatie/data-transfer-object/commit/66618c96c88f83a9e6c19eb2a0c8868ea18974d9 didn't
consider serialization where we also need to skip it 🤷‍♀️

~Batteries~ test included!