### PR TITLE
docs: update json2dto readme description

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ We publish all received postcards [on our company website](https://spatie.be/en/
 
 ## External tools
 
-- [json2dto](https://json2dto.atymic.dev/): a GUI to convert JSON objects to DTO classes
+- [json2dto](https://json2dto.atymic.dev): a GUI to convert JSON objects to DTO classes (with nesting support). Also provides a [CLI tool](https://github.com/atymic/json2dto#cli-tool) for local usage.
 
 ## Credits
 


### PR DESCRIPTION
Since [json2dto](https://github.com/atymic/json2dto) now has a CLI I thought it would be worth mentioning that in the description :)

Both the CLI and GUI support nested DTOs as well now, so added that to the description as well.

Thanks!