### PR TITLE
Fix uninitialized property check

### DIFF
--- a/src/FieldValidator.php
+++ b/src/FieldValidator.php
@@ -39,9 +39,11 @@ class FieldValidator
 
     public static function fromReflection(ReflectionProperty $property): FieldValidator
     {
+        $defaultProperties = $property->getDeclaringClass()->getDefaultProperties();
+
         return new self(
             $property->getDocComment() ?: null,
-            $property->isDefault()
+            ($defaultProperties[$property->name] ?? null) !== null
         );
     }
 

--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -81,7 +81,7 @@ class DataTransferObjectTest extends TestCase
     public function null_is_allowed_only_if_explicitly_specified()
     {
         $this->expectException(DataTransferObjectError::class);
-        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `string`, instead got value `null`, which is NULL/');
+        $this->expectExceptionMessageRegExp('/Non-nullable property `class@anonymous[^:]+::foo` has not been initialized./');
 
         new class(['foo' => null]) extends DataTransferObject {
             /** @var string */
@@ -237,7 +237,7 @@ class DataTransferObjectTest extends TestCase
     public function an_exception_is_thrown_when_property_was_not_initialised()
     {
         $this->expectException(DataTransferObjectError::class);
-        $this->expectExceptionMessageRegExp('/Invalid type: expected `class@anonymous[^:]+::foo` to be of type `string`, instead got value `null`, which is NULL/');
+        $this->expectExceptionMessageRegExp('/Non-nullable property `class@anonymous[^:]+::foo` has not been initialized./');
 
         new class([]) extends DataTransferObject {
             /** @var string */
@@ -351,7 +351,7 @@ class DataTransferObjectTest extends TestCase
     public function nested_array_dtos_cannot_cast_with_null()
     {
         $this->expectException(DataTransferObjectError::class);
-        $this->expectExceptionMessage('Invalid type: expected `Spatie\DataTransferObject\Tests\TestClasses\NestedParentOfMany::children` to be of type `\Spatie\DataTransferObject\Tests\TestClasses\NestedChild[]`, instead got value `null`, which is NULL.');
+        $this->expectExceptionMessage('Non-nullable property `Spatie\DataTransferObject\Tests\TestClasses\NestedParentOfMany::children` has not been initialized.');
 
         new NestedParentOfMany([
             'name' => 'parent',
@@ -472,8 +472,8 @@ class DataTransferObjectTest extends TestCase
         $this->assertSame(1, $arrayOf[0]->testProperty);
         $this->assertSame(2, $arrayOf[1]->testProperty);
     }
-  
-      
+
+
     /** @test */
     public function ignore_static_public_properties()
     {


### PR DESCRIPTION
The `$hasDefaultValue` property on `FieldValidator` was incorrectly being set to the value of `$property->isDefault()`. `isDefault()` indicates if a property was declared at compile time or created at run time - it doesn't have anything to do with whether or not the property has a default value ([PHP docs for ReflectionProperty::isDefault](https://www.php.net/manual/en/reflectionproperty.isdefault.php))

Here is a slightly modified version of the first example from the docs:

```php
<?php

class Foo {
    public $bar;
}

$o = new Foo();
$o->bar = 42;
$o->baz = 42;

$ro = new ReflectionObject($o);
var_dump($ro->getProperty('bar')->isDefault()); // bool(true)
var_dump($ro->getProperty('baz')->isDefault()); // bool(false)
```

`bar->isDefault()` is `true` because it was declared in the class (note that it _doesn't_ have a default value).

This PR modifies `$hasDefaultValue` to instead look at the default properties of the class and determine if the default value for the property is not `null`, which would indicate that it has a default value. I also modified three of the tests that should have been seeing the "uninitialized" error message, but were instead seeing the "invalidType" error message.