### PR TITLE
Add properties to exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,20 @@ If not, a `Spatie\DataTransferObject\DataTransferObjectError` will be thrown.
 
 Likewise, if you're trying to set non-defined properties, you'll get a `DataTransferObjectError`.
 
+### Exception Properties
+
+The `DataTransferObjectError` exception object exposes information about the specific error through various getter methods:
+
+| Exception Method | Description | Applies To<br>Error Types |
+| ------ | ----------- | ----------- |
+| `getError(): string` | Type of error being thrown<br>Error types: unknownProperties, invalidType, uninitialized, immutable | N/A
+| `getClass(): string` | Name of the data transfer object class | unknownProperties<br>invalidType<br>uninitialized<br>immutable
+| `getProperty(): string` | Name of the data transfer object property | invalidType<br>uninitialized<br>immutable
+| `getProperties(): string[]` | Names of the data transfer object properties | unknownProperties
+| `getValue(): mixed` | Value of the data transfer object property | invalidType
+| `getType(): string` | Type of the data transfer object property | invalidType
+| `getExpectedTypes(): string[]` | Expected types of the data transfer object property | invalidType
+
 ### Flexible Data Transfer Objects
 Sometimes you might want to be able to instantiate a DTO with a subset of an array. A good example of this is a large
 API response where only a small amount of the fields are used. Normally, if you tried to instantiate a standard DTO

--- a/src/DataTransferObjectError.php
+++ b/src/DataTransferObjectError.php
@@ -8,11 +8,23 @@ use TypeError;
 
 class DataTransferObjectError extends TypeError
 {
+    use HasErrorProperties;
+
+    public function __construct($message, $properties = [])
+    {
+        parent::__construct($message);
+        $this->setProperties($properties);
+    }
+
     public static function unknownProperties(array $properties, string $className): DataTransferObjectError
     {
         $propertyNames = implode('`, `', $properties);
 
-        return new self("Public properties `{$propertyNames}` not found on {$className}");
+        return new self("Public properties `{$propertyNames}` not found on {$className}", [
+            'error'      => __FUNCTION__,
+            'class'      => $className,
+            'properties' => $properties,
+        ]);
     }
 
     public static function invalidType(
@@ -35,18 +47,32 @@ class DataTransferObjectError extends TypeError
             $value = 'array';
         }
 
-        $expectedTypes = implode(', ', $expectedTypes);
+        $expectedTypesList = implode(', ', $expectedTypes);
 
-        return new self("Invalid type: expected `{$class}::{$field}` to be of type `{$expectedTypes}`, instead got value `{$value}`, which is {$currentType}.");
+        return new self("Invalid type: expected `{$class}::{$field}` to be of type `{$expectedTypesList}`, instead got value `{$value}`, which is {$currentType}.", [
+            'error'         => __FUNCTION__,
+            'class'         => $class,
+            'property'      => $field,
+            'value'         => $value,
+            'type'          => $currentType,
+            'expectedTypes' => $expectedTypes,
+        ]);
     }
 
     public static function uninitialized(string $class, string $field): DataTransferObjectError
     {
-        return new self("Non-nullable property `{$class}::{$field}` has not been initialized.");
+        return new self("Non-nullable property `{$class}::{$field}` has not been initialized.", [
+            'error'    => __FUNCTION__,
+            'class'    => $class,
+            'property' => $field,
+        ]);
     }
 
     public static function immutable(string $property): DataTransferObjectError
     {
-        return new self("Cannot change the value of property {$property} on an immutable data transfer object");
+        return new self("Cannot change the value of property {$property} on an immutable data transfer object", [
+            'error'    => __FUNCTION__,
+            'property' => $property,
+        ]);
     }
 }

--- a/src/HasErrorProperties.php
+++ b/src/HasErrorProperties.php
@@ -18,8 +18,8 @@ trait HasErrorProperties
     /** @var array */
     protected $properties = [];
 
-    /** @var string */
-    protected $value = '';
+    /** @var mixed */
+    protected $value;
 
     /** @var string */
     protected $type = '';
@@ -95,9 +95,9 @@ trait HasErrorProperties
      *
      * Applies to error types: invalidType
      *
-     * @return string
+     * @return mixed
      */
-    public function getValue(): string
+    public function getValue()
     {
         return $this->value;
     }

--- a/src/HasErrorProperties.php
+++ b/src/HasErrorProperties.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject;
+
+trait HasErrorProperties
+{
+    /** @var string */
+    protected $error = '';
+
+    /** @var string */
+    protected $class = '';
+
+    /** @var string */
+    protected $property = '';
+
+    /** @var array */
+    protected $properties = [];
+
+    /** @var string */
+    protected $value = '';
+
+    /** @var string */
+    protected $type = '';
+
+    /** @var array */
+    protected $expectedTypes = [];
+
+    /**
+     * Set the error properties
+     *
+     * @param array $properties
+     */
+    protected function setProperties(array $properties): void
+    {
+        foreach ($properties as $key => $value) {
+            if (property_exists($this, $key)) {
+                $this->$key = $value;
+            }
+        }
+    }
+
+    /**
+     * Get the type of error being thrown
+     * The error type corresponds to the name of the function that generated it
+     *
+     * Error types: unknownProperties, invalidType, uninitialized, immutable
+     *
+     * @return string
+     */
+    public function getError(): string
+    {
+        return $this->error;
+    }
+
+    /**
+     * Get the name of the data transfer object class
+     *
+     * Applies to error types: unknownProperties, invalidType, uninitialized, immutable
+     *
+     * @return string
+     */
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    /**
+     * Get the name of the data transfer object property
+     *
+     * Applies to error types: invalidType, uninitialized, immutable
+     *
+     * @return string
+     */
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    /**
+     * Get the names of the data transfer object properties
+     *
+     * Applies to error types: unknownProperties
+     *
+     * @return array
+     */
+    public function getProperties(): array
+    {
+        return $this->properties;
+    }
+
+    /**
+     * Get the value of the data transfer object property
+     *
+     * Applies to error types: invalidType
+     *
+     * @return string
+     */
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * Get the type of the data transfer object property
+     *
+     * Applies to error types: invalidType
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * Get the expected types of the data transfer object property
+     *
+     * Applies to error types: invalidType
+     *
+     * @return array
+     */
+    public function getExpectedTypes(): array
+    {
+        return $this->expectedTypes;
+    }
+}

--- a/tests/ImmutableTest.php
+++ b/tests/ImmutableTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\DataTransferObject\Tests;
 
+use Spatie\DataTransferObject\DataTransferObject;
 use Spatie\DataTransferObject\DataTransferObjectError;
 use Spatie\DataTransferObject\Tests\TestClasses\NullableTestDataTransferObject;
 use Spatie\DataTransferObject\Tests\TestClasses\TestDataTransferObject;
@@ -21,6 +22,21 @@ class ImmutableTest extends TestCase
         $this->expectExceptionMessage('Cannot change the value of property testProperty on an immutable data transfer object');
 
         $dto->testProperty = 2;
+    }
+
+    /** @test */
+    public function immutable_errors_set_exception_properties()
+    {
+        try {
+            $dto = TestDataTransferObject::immutable([
+                'testProperty' => 1,
+            ]);
+
+            $dto->testProperty = 2;
+        } catch (DataTransferObjectError $error) {
+            $this->assertEquals('immutable', $error->getError());
+            $this->assertEquals('testProperty', $error->getProperty());
+        }
     }
 
     /** @test */


### PR DESCRIPTION
Because the same `DataTransferObjectError` exception is thrown for every possible error, it is difficult to properly handle the specific error. This PR adds additional contextual information about the specific error to the exception object and exposes that information through various getter methods. The getter methods are explained in the readme.

Another way of doing this would be to create separate exceptions for each error type that extend the base `DataTransferObjectError` class. I can refactor to that if preferred.

Thanks!