### PR TITLE
readme: update collection examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,21 @@ class PostCollection extends DataTransferObjectCollection
 }
 ```
 
-By overriding the `current` method, you'll get auto completion in your IDE, 
-and use the collections like so.
+By overriding the `current` method, you'll get auto completion in your IDE.
+Alternatively you can also use a phpdoc for this:
+
+```php
+use \Spatie\DataTransferObject\DataTransferObjectCollection;
+
+/**
+ * @method PostData current
+ */
+class PostCollection extends DataTransferObjectCollection
+{
+}
+```
+
+Then you can use the collections like so:
 
 ```php
 foreach ($postCollection as $postData) {
@@ -209,14 +222,7 @@ class PostCollection extends DataTransferObjectCollection
 {
     public static function create(array $data): PostCollection
     {
-        $collection = [];
-
-        foreach ($data as $item)
-        {
-            $collection[] = PostData::create($item);
-        }
-
-        return new self($collection);
+        return new static(PostData::arrayOf($data));
     }
 }
 ```


### PR DESCRIPTION
- I introduced arrayOf some time ago and it turns out, it's perfect with for the collection
- `@method` can be used, IDEs (PhpStorm) can still properly autocomplete this.

Since the `Collection` is supposed to be a small enhancement for type safety, I thought making it less boiler-platey might be welcome