### PR TITLE
Support basic array<…> and array<…,…> syntax

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -69,7 +69,12 @@ abstract class DataTransferObject
                 throw DataTransferObjectError::invalidType(
                     static::class,
                     $field,
-                    $validator->allowedTypes,
+                    array_map(
+                        function (FieldType $type): string {
+                            return $type->getValueType();
+                        },
+                        $validator->allowedTypes,
+                    ),
                     $value
                 );
             }

--- a/src/FieldType.php
+++ b/src/FieldType.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject;
+
+class FieldType
+{
+    /** @var string */
+    private $valueType;
+
+    /** @var string|null */
+    private $keyType;
+
+    public function __construct(string $valueType, ?string $keyType = null)
+    {
+        $this->valueType = $valueType;
+        $this->keyType = $keyType;
+    }
+
+    public function getValueType(): string
+    {
+        return $this->valueType;
+    }
+
+    public function getKeyType(): string
+    {
+        return $this->keyType;
+    }
+
+    public function hasKeyType(): bool
+    {
+        return null !== $this->keyType;
+    }
+}

--- a/src/ValueCaster.php
+++ b/src/ValueCaster.php
@@ -11,11 +11,18 @@ class ValueCaster
             : $this->castValue($value, $validator->allowedTypes);
     }
 
+    /**
+     * @param mixed $value
+     * @param FieldType[] $allowedTypes
+     * @return mixed
+     */
     public function castValue($value, array $allowedTypes)
     {
         $castTo = null;
 
         foreach ($allowedTypes as $type) {
+            $type = $type->getValueType();
+
             if (! is_subclass_of($type, DataTransferObject::class)) {
                 continue;
             }
@@ -32,11 +39,18 @@ class ValueCaster
         return new $castTo($value);
     }
 
+    /**
+     * @param mixed $values
+     * @param FieldType[] $allowedArrayTypes
+     * @return array
+     */
     public function castCollection($values, array $allowedArrayTypes)
     {
         $castTo = null;
 
         foreach ($allowedArrayTypes as $type) {
+            $type = $type->getValueType();
+
             if (! is_subclass_of($type, DataTransferObject::class)) {
                 continue;
             }

--- a/tests/FieldValidatorTest.php
+++ b/tests/FieldValidatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests;
 
+use Spatie\DataTransferObject\FieldType;
 use Spatie\DataTransferObject\FieldValidator;
 
 class Foo {}
@@ -27,28 +28,28 @@ class FieldValidatorTest extends TestCase
     /** @test */
     public function allowed_types()
     {
-        $this->assertEquals(['string'], (new FieldValidator('/** @var string */'))->allowedTypes);
-        $this->assertEquals(['\A\B'], (new FieldValidator('/** @var \A\B */'))->allowedTypes);
-        $this->assertEquals(['string', 'integer'], (new FieldValidator('/** @var string|integer */'))->allowedTypes);
-        $this->assertEquals(['string', 'integer'], (new FieldValidator('/** @var string|int */'))->allowedTypes);
-        $this->assertEquals(['boolean'], (new FieldValidator('/** @var bool */'))->allowedTypes);
-        $this->assertEquals(['double'], (new FieldValidator('/** @var float */'))->allowedTypes);
+        $this->assertEquals([new FieldType('string')], (new FieldValidator('/** @var string */'))->allowedTypes);
+        $this->assertEquals([new FieldType('\A\B')], (new FieldValidator('/** @var \A\B */'))->allowedTypes);
+        $this->assertEquals([new FieldType('string'), new FieldType('integer')], (new FieldValidator('/** @var string|integer */'))->allowedTypes);
+        $this->assertEquals([new FieldType('string'), new FieldType('integer')], (new FieldValidator('/** @var string|int */'))->allowedTypes);
+        $this->assertEquals([new FieldType('boolean')], (new FieldValidator('/** @var bool */'))->allowedTypes);
+        $this->assertEquals([new FieldType('double')], (new FieldValidator('/** @var float */'))->allowedTypes);
     }
 
     /** @test */
     public function allowed_array_types()
     {
-        $this->assertEquals(['string'], (new FieldValidator('/** @var string[] */'))->allowedArrayTypes);
-        $this->assertEquals(['\A\B'], (new FieldValidator('/** @var \A\B[] */'))->allowedArrayTypes);
-        $this->assertEquals(['string', 'integer'], (new FieldValidator('/** @var string[]|int[] */'))->allowedArrayTypes);
-        $this->assertEquals(['string'], (new FieldValidator('/** @var string[]|int */'))->allowedArrayTypes);
-        $this->assertEquals(['string'], (new FieldValidator('/** @var iterable<string> */'))->allowedArrayTypes);
-        $this->assertEquals(['string', 'integer'], (new FieldValidator('/** @var iterable<string>|int[] */'))->allowedArrayTypes);
-        $this->assertEquals(['string'], (new FieldValidator('/** @var array<string> */'))->allowedArrayTypes);
-        $this->assertEquals(['integer'], (new FieldValidator('/** @var array<int> */'))->allowedArrayTypes);
-        $this->assertEquals([['integer', 'string']], (new FieldValidator('/** @var array<int,string> */'))->allowedArrayTypes);
-        $this->assertEquals([['string', 'integer']], (new FieldValidator('/** @var array<string,int> */'))->allowedArrayTypes);
-        $this->assertEquals([['string', '\A\B']], (new FieldValidator('/** @var array<string,\A\B> */'))->allowedArrayTypes);
+        $this->assertEquals([new FieldType('string')], (new FieldValidator('/** @var string[] */'))->allowedArrayTypes);
+        $this->assertEquals([new FieldType('\A\B')], (new FieldValidator('/** @var \A\B[] */'))->allowedArrayTypes);
+        $this->assertEquals([new FieldType('string'), new FieldType('integer')], (new FieldValidator('/** @var string[]|int[] */'))->allowedArrayTypes);
+        $this->assertEquals([new FieldType('string')], (new FieldValidator('/** @var string[]|int */'))->allowedArrayTypes);
+        $this->assertEquals([new FieldType('string')], (new FieldValidator('/** @var iterable<string> */'))->allowedArrayTypes);
+        $this->assertEquals([new FieldType('string'), new FieldType('integer')], (new FieldValidator('/** @var iterable<string>|int[] */'))->allowedArrayTypes);
+        $this->assertEquals([new FieldType('string')], (new FieldValidator('/** @var array<string> */'))->allowedArrayTypes);
+        $this->assertEquals([new FieldType('integer')], (new FieldValidator('/** @var array<int> */'))->allowedArrayTypes);
+        $this->assertEquals([new FieldType('string', 'integer')], (new FieldValidator('/** @var array<int,string> */'))->allowedArrayTypes);
+        $this->assertEquals([new FieldType('integer', 'string')], (new FieldValidator('/** @var array<string,int> */'))->allowedArrayTypes);
+        $this->assertEquals([new FieldType('\A\B', 'string')], (new FieldValidator('/** @var array<string,\A\B> */'))->allowedArrayTypes);
     }
 
     /** @test */

--- a/tests/FieldValidatorTest.php
+++ b/tests/FieldValidatorTest.php
@@ -44,6 +44,11 @@ class FieldValidatorTest extends TestCase
         $this->assertEquals(['string'], (new FieldValidator('/** @var string[]|int */'))->allowedArrayTypes);
         $this->assertEquals(['string'], (new FieldValidator('/** @var iterable<string> */'))->allowedArrayTypes);
         $this->assertEquals(['string', 'integer'], (new FieldValidator('/** @var iterable<string>|int[] */'))->allowedArrayTypes);
+        $this->assertEquals(['string'], (new FieldValidator('/** @var array<string> */'))->allowedArrayTypes);
+        $this->assertEquals(['integer'], (new FieldValidator('/** @var array<int> */'))->allowedArrayTypes);
+        $this->assertEquals([['integer', 'string']], (new FieldValidator('/** @var array<int,string> */'))->allowedArrayTypes);
+        $this->assertEquals([['string', 'integer']], (new FieldValidator('/** @var array<string,int> */'))->allowedArrayTypes);
+        $this->assertEquals([['string', '\A\B']], (new FieldValidator('/** @var array<string,\A\B> */'))->allowedArrayTypes);
     }
 
     /** @test */


### PR DESCRIPTION
Problem: I can't use `array<int,string>` or `array<string,string>` (for e.g. static analyzers) because I always get an exception like this:
```
Spatie\DataTransferObject\DataTransferObjectError : Invalid type: expected `DTO::Property` to be of type `array<string`, instead got value `array`, which is array.
```
This PR is an attempt to fix this, see the tests.

In case of violations, the error message isn't very helpful, it will be something like:
```
Invalid type: expected `DTO::Property` to be of type `array<string,string>`, instead got value `array`, which is array.
```
But that's a limitation of the design of the `\Spatie\DataTransferObject\FieldValidator::isValidType`: it can only return `true`/`false` but would need more specific details here.

I don't think the implementation is "super cool", but gets the job done. It's basically the first brain-dump approach to get it working. Would appreciate feedback to improve this!