### PR TITLE
Support typed properties

### DIFF
--- a/src/FieldValidator.php
+++ b/src/FieldValidator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Spatie\DataTransferObject;
 
-use ReflectionProperty;
 use ReflectionNamedType;
+use ReflectionProperty;
 
 class FieldValidator
 {

--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -14,6 +14,7 @@ use Spatie\DataTransferObject\Tests\TestClasses\NestedParent;
 use Spatie\DataTransferObject\Tests\TestClasses\NestedParentOfMany;
 use Spatie\DataTransferObject\Tests\TestClasses\OtherClass;
 use Spatie\DataTransferObject\Tests\TestClasses\TestDataTransferObject;
+use Spatie\DataTransferObject\Tests\TestClasses\TypedNestedParent;
 
 class DataTransferObjectTest extends TestCase
 {
@@ -280,6 +281,23 @@ class DataTransferObjectTest extends TestCase
         ];
 
         $object = new NestedParent($data);
+
+        $this->assertInstanceOf(NestedChild::class, $object->child);
+        $this->assertEquals('parent', $object->name);
+        $this->assertEquals('child', $object->child->name);
+    }
+
+    /** @test */
+    public function nested_typed_dtos_are_automatically_cast_from_arrays_to_objects()
+    {
+        $data = [
+            'name' => 'parent',
+            'child' => [
+                'name' => 'child',
+            ],
+        ];
+
+        $object = new TypedNestedParent($data);
 
         $this->assertInstanceOf(NestedChild::class, $object->child);
         $this->assertEquals('parent', $object->name);

--- a/tests/TestClasses/TypedNestedParent.php
+++ b/tests/TestClasses/TypedNestedParent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests\TestClasses;
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class TypedNestedParent extends DataTransferObject
+{
+    public NestedChild $child;
+
+    /** @var string */
+    public $name;
+}


### PR DESCRIPTION
With PR adds support for typed properties in the PHP 7.4 without the need for docblock comments.

There are limitations, in that typed arrays are not yet supported, however primitives, nullable types, objects and nested DTOs are all supported.

Gauging interest in the approach here, so if this is agreeable I'll updated README too.