### PR TITLE
Fix: Validator for typed 7.4 properties

### DIFF
--- a/src/PropertyFieldValidator.php
+++ b/src/PropertyFieldValidator.php
@@ -68,7 +68,7 @@ class PropertyFieldValidator extends FieldValidator
         return array_filter(array_map(
             function (?ReflectionType $type) {
                 if ($type instanceof ReflectionNamedType) {
-                    return $type->getName();
+                    $type = $type->getName();
                 }
 
                 return self::$typeMapping[$type] ?? $type;

--- a/tests/PropertyFieldValidatorTest.php
+++ b/tests/PropertyFieldValidatorTest.php
@@ -27,8 +27,26 @@ class PropertyFieldValidatorTest extends TestCase
             public A $a;
         });
 
-        $this->assertEquals(['int'], (new PropertyFieldValidator($int))->allowedTypes);
+        $this->assertEquals(['integer'], (new PropertyFieldValidator($int))->allowedTypes);
         $this->assertEquals([A::class], (new PropertyFieldValidator($a))->allowedTypes);
+    }
+
+    /** @test */
+    public function allowed_types_are_valid()
+    {
+        [$int, $bool, $string, $float, $a] = $this->getProperties(new class() {
+            public int $int;
+            public bool $bool;
+            public string $string;
+            public float $float;
+            public A $a;
+        });
+
+        $this->assertTrue((new PropertyFieldValidator($int))->isValidType(1), "Failed asserting that '1' is a valid integer!");
+        $this->assertTrue((new PropertyFieldValidator($bool))->isValidType(true), "Failed asserting that 'true' is a valid boolean!");
+        $this->assertTrue((new PropertyFieldValidator($string))->isValidType('string'), "Failed asserting that 'string' is a valid string!");
+        $this->assertTrue((new PropertyFieldValidator($float))->isValidType(10.55), "Failed asserting that '10.55' is a valid float!");
+        $this->assertTrue((new PropertyFieldValidator($a))->isValidType(new A()), "Failed asserting that the object 'A' is a valid type!");
     }
 
     /** @test */


### PR DESCRIPTION
The reflection types don't seem to be being passed to the TypeMapping which leads to wrong results in the validator because it uses `gettype` which has a different result than the reflection types.