### PR TITLE
Add support for self & static property types

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -184,7 +184,7 @@ abstract class DataTransferObject
 
                 $field = $reflectionProperty->getName();
 
-                $properties[$field] = FieldValidator::fromReflection($reflectionProperty);
+                $properties[$field] = FieldValidator::fromReflection($reflectionProperty, $class);
             }
 
             return $properties;

--- a/src/PropertyFieldValidator.php
+++ b/src/PropertyFieldValidator.php
@@ -10,8 +10,10 @@ use ReflectionType;
 
 class PropertyFieldValidator extends FieldValidator
 {
-    public function __construct(ReflectionProperty $property)
+    public function __construct(ReflectionProperty $property, \ReflectionClass $class)
     {
+        $this->property = $property;
+        $this->class = $class;
         $this->hasTypeDeclaration = $property->hasType();
         $this->hasDefaultValue = $property->isDefault();
         $this->isNullable = $this->resolveAllowsNull($property);
@@ -71,7 +73,7 @@ class PropertyFieldValidator extends FieldValidator
                     $type = $type->getName();
                 }
 
-                return self::$typeMapping[$type] ?? $type;
+                return $this->normaliseType($type);
             },
             $types
         ));

--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -13,6 +13,10 @@ use Spatie\DataTransferObject\Tests\TestClasses\NestedChild;
 use Spatie\DataTransferObject\Tests\TestClasses\NestedParent;
 use Spatie\DataTransferObject\Tests\TestClasses\NestedParentOfMany;
 use Spatie\DataTransferObject\Tests\TestClasses\OtherClass;
+use Spatie\DataTransferObject\Tests\TestClasses\SelfDataTransferObject;
+use Spatie\DataTransferObject\Tests\TestClasses\SelfExtensionDataTransferObject;
+use Spatie\DataTransferObject\Tests\TestClasses\StaticDataTransferObject;
+use Spatie\DataTransferObject\Tests\TestClasses\StaticExtensionDataTransferObject;
 use Spatie\DataTransferObject\Tests\TestClasses\TestDataTransferObject;
 
 class DataTransferObjectTest extends TestCase
@@ -284,6 +288,42 @@ class DataTransferObjectTest extends TestCase
         $this->assertInstanceOf(NestedChild::class, $object->child);
         $this->assertEquals('parent', $object->name);
         $this->assertEquals('child', $object->child->name);
+    }
+
+    /** @test */
+    public function nested_self_dtos_are_automatically_cast_from_arrays_to_instance_of_self()
+    {
+        $data = [
+            'name' => 'extension',
+            'self' => [
+                'name' => 'self',
+            ],
+        ];
+
+        $object = new SelfExtensionDataTransferObject($data);
+
+        $this->assertInstanceOf(SelfDataTransferObject::class, $object->self);
+        $this->assertNotInstanceOf(SelfExtensionDataTransferObject::class, $object->self);
+        $this->assertEquals('extension', $object->name);
+        $this->assertEquals('self', $object->self->name);
+    }
+
+    /** @test */
+    public function nested_static_dtos_are_automatically_cast_from_arrays_to_instance_of_static()
+    {
+        $data = [
+            'name' => 'extension',
+            'static' => [
+                'name' => 'static',
+            ],
+        ];
+
+        $object = new StaticExtensionDataTransferObject($data);
+
+        $this->assertInstanceOf(StaticDataTransferObject::class, $object->static);
+        $this->assertInstanceOf(StaticExtensionDataTransferObject::class, $object->static);
+        $this->assertEquals('extension', $object->name);
+        $this->assertEquals('static', $object->static->name);
     }
 
     /** @test */

--- a/tests/DocblockFieldValidatorTest.php
+++ b/tests/DocblockFieldValidatorTest.php
@@ -4,10 +4,19 @@ declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests;
 
+use ReflectionClass;
 use Spatie\DataTransferObject\DocblockFieldValidator;
 
 class Foo
 {
+    /** @var self */
+    public self $self;
+    /** @var static */
+    public $static;
+    /** @var self[] */
+    public $selfArray;
+    /** @var static[] */
+    public $staticArray;
 }
 class FooChild extends Foo
 {
@@ -21,100 +30,235 @@ class DocblockFieldValidatorTest extends TestCase
     /** @test */
     public function nullable()
     {
-        $this->assertTrue((new DocblockFieldValidator(''))->isNullable);
-        $this->assertTrue((new DocblockFieldValidator('/**  */'))->isNullable);
-        $this->assertTrue((new DocblockFieldValidator('/** @var string|null */'))->isNullable);
-        $this->assertTrue((new DocblockFieldValidator('/** @var null */'))->isNullable);
-        $this->assertTrue((new DocblockFieldValidator('/** @var mixed */'))->isNullable);
+        [$class, $noDocBlock, $emptyDocBlock, $stringOrNull, $null, $mixed, $string] = $this->getClassAndProperties(new class() {
+            public $noDocBlock;
+            /**  */
+            public $emptyDocBlock;
+            /** @var string|null */
+            public $stringOrNull;
+            /** @var null */
+            public $null;
+            /** @var mixed */
+            public $mixed;
+            /** @var string */
+            public $string;
+        });
 
-        $this->assertFalse((new DocblockFieldValidator('/** @var string */'))->isNullable);
+        $this->assertTrue((new DocblockFieldValidator('', $noDocBlock, $class))->isNullable);
+        $this->assertTrue((new DocblockFieldValidator($emptyDocBlock->getDocComment(), $emptyDocBlock, $class))->isNullable);
+        $this->assertTrue((new DocblockFieldValidator($stringOrNull->getDocComment(), $stringOrNull, $class))->isNullable);
+        $this->assertTrue((new DocblockFieldValidator($null->getDocComment(), $null, $class))->isNullable);
+        $this->assertTrue((new DocblockFieldValidator($mixed->getDocComment(), $mixed, $class))->isNullable);
+
+        $this->assertFalse((new DocblockFieldValidator($string->getDocComment(), $string, $class))->isNullable);
     }
 
     /** @test */
     public function allowed_types()
     {
-        $this->assertEquals(['string'], (new DocblockFieldValidator('/** @var string */'))->allowedTypes);
-        $this->assertEquals(['\A\B'], (new DocblockFieldValidator('/** @var \A\B */'))->allowedTypes);
-        $this->assertEquals(['string', 'integer'], (new DocblockFieldValidator('/** @var string|integer */'))->allowedTypes);
-        $this->assertEquals(['string', 'integer'], (new DocblockFieldValidator('/** @var string|int */'))->allowedTypes);
-        $this->assertEquals(['boolean'], (new DocblockFieldValidator('/** @var bool */'))->allowedTypes);
-        $this->assertEquals(['double'], (new DocblockFieldValidator('/** @var float */'))->allowedTypes);
+        [$class, $string, $b, $stringOrInteger, $stringOrInt, $bool, $float] = $this->getClassAndProperties(new class() {
+            /** @var string */
+            public $string;
+            /** @var \A\B */
+            public $b;
+            /** @var string|integer */
+            public $stringOrInteger;
+            /** @var string|int */
+            public $stringOrInt;
+            /** @var bool */
+            public $bool;
+            /** @var float */
+            public $float;
+        });
+
+        $this->assertEquals(['string'], (new DocblockFieldValidator($string->getDocComment(), $string, $class))->allowedTypes);
+        $this->assertEquals(['\A\B'], (new DocblockFieldValidator($b->getDocComment(), $b, $class))->allowedTypes);
+        $this->assertEquals(['string', 'integer'], (new DocblockFieldValidator($stringOrInteger->getDocComment(), $stringOrInteger, $class))->allowedTypes);
+        $this->assertEquals(['string', 'integer'], (new DocblockFieldValidator($stringOrInt->getDocComment(), $stringOrInt, $class))->allowedTypes);
+        $this->assertEquals(['boolean'], (new DocblockFieldValidator($bool->getDocComment(), $bool, $class))->allowedTypes);
+        $this->assertEquals(['double'], (new DocblockFieldValidator($float->getDocComment(), $float, $class))->allowedTypes);
     }
 
     /** @test */
     public function allowed_array_types()
     {
-        $this->assertEquals(['string'], (new DocblockFieldValidator('/** @var string[] */'))->allowedArrayTypes);
-        $this->assertEquals(['\A\B'], (new DocblockFieldValidator('/** @var \A\B[] */'))->allowedArrayTypes);
-        $this->assertEquals(['string', 'integer'], (new DocblockFieldValidator('/** @var string[]|int[] */'))->allowedArrayTypes);
-        $this->assertEquals(['string'], (new DocblockFieldValidator('/** @var string[]|int */'))->allowedArrayTypes);
-        $this->assertEquals(['string'], (new DocblockFieldValidator('/** @var iterable<string> */'))->allowedArrayTypes);
-        $this->assertEquals(['string', 'integer'], (new DocblockFieldValidator('/** @var iterable<string>|int[] */'))->allowedArrayTypes);
+        [$class, $stringArray, $bArray, $stringArrayOrIntArray, $stringArrayOrInt, $stringIterable, $iterableStringOrIntArray] = $this->getClassAndProperties(new class() {
+            /** @var string[] */
+            public $stringArray;
+            /** @var \A\B[] */
+            public $bArray;
+            /** @var string[]|int[] */
+            public $stringArrayOrIntArray;
+            /** @var string[]|int */
+            public $stringArrayOrInt;
+            /** @var iterable<string> */
+            public $stringIterable;
+            /** @var iterable<string>|int[] */
+            public $iterableStringOrIntArray;
+        });
+
+        $this->assertEquals(['string'], (new DocblockFieldValidator($stringArray->getDocComment(), $stringArray, $class))->allowedArrayTypes);
+        $this->assertEquals(['\A\B'], (new DocblockFieldValidator($bArray->getDocComment(), $bArray, $class))->allowedArrayTypes);
+        $this->assertEquals(['string', 'integer'], (new DocblockFieldValidator($stringArrayOrIntArray->getDocComment(), $stringArrayOrIntArray, $class))->allowedArrayTypes);
+        $this->assertEquals(['string'], (new DocblockFieldValidator($stringArrayOrInt->getDocComment(), $stringArrayOrInt, $class))->allowedArrayTypes);
+        $this->assertEquals(['string'], (new DocblockFieldValidator($stringIterable->getDocComment(), $stringIterable, $class))->allowedArrayTypes);
+        $this->assertEquals(['string', 'integer'], (new DocblockFieldValidator($iterableStringOrIntArray->getDocComment(), $iterableStringOrIntArray, $class))->allowedArrayTypes);
     }
 
     /** @test */
     public function empty_type_is_always_valid()
     {
-        $this->assertTrue((new DocblockFieldValidator(''))->isValidType(1));
-        $this->assertTrue((new DocblockFieldValidator(''))->isValidType('a'));
-        $this->assertTrue((new DocblockFieldValidator(''))->isValidType(null));
+        [$class, $empty] = $this->getClassAndProperties(new class() {
+            public $empty;
+        });
+
+        $this->assertTrue((new DocblockFieldValidator('', $empty, $class))->isValidType(1));
+        $this->assertTrue((new DocblockFieldValidator('', $empty, $class))->isValidType('a'));
+        $this->assertTrue((new DocblockFieldValidator('', $empty, $class))->isValidType(null));
     }
 
     /** @test */
     public function mixed_is_always_valid()
     {
-        $this->assertTrue((new DocblockFieldValidator('/** @var mixed */'))->isValidType(1));
-        $this->assertTrue((new DocblockFieldValidator('/** @var mixed */'))->isValidType('a'));
-        $this->assertTrue((new DocblockFieldValidator('/** @var mixed */'))->isValidType(null));
+        [$class, $mixed] = $this->getClassAndProperties(new class() {
+            /** @var mixed */
+            public $mixed;
+        });
+
+        $this->assertTrue((new DocblockFieldValidator($mixed->getDocComment(), $mixed, $class))->isValidType(1));
+        $this->assertTrue((new DocblockFieldValidator($mixed->getDocComment(), $mixed, $class))->isValidType('a'));
+        $this->assertTrue((new DocblockFieldValidator($mixed->getDocComment(), $mixed, $class))->isValidType(null));
     }
 
     /** @test */
     public function nullable_types_are_validated()
     {
-        $this->assertTrue((new DocblockFieldValidator(''))->isValidType(null));
-        $this->assertTrue((new DocblockFieldValidator('/**  */'))->isValidType(null));
-        $this->assertTrue((new DocblockFieldValidator('/** @var string|null */'))->isValidType(null));
-        $this->assertTrue((new DocblockFieldValidator('/** @var null */'))->isValidType(null));
-        $this->assertTrue((new DocblockFieldValidator('/** @var mixed */'))->isValidType(null));
-        $this->assertTrue((new DocblockFieldValidator('/** @var ?string */'))->isValidType(null));
+        [$class, $noDocBlock, $emptyDocBlock, $stringOrNull, $null, $mixed, $nullableString] = $this->getClassAndProperties(new class() {
+            public $noDocBlock;
+            /**  */
+            public $emptyDocBlock;
+            /** @var string|null */
+            public $stringOrNull;
+            /** @var null */
+            public $null;
+            /** @var mixed */
+            public $mixed;
+            /** @var ?string */
+            public $nullableString;
+        });
+
+        $this->assertTrue((new DocblockFieldValidator('', $noDocBlock, $class))->isValidType(null));
+        $this->assertTrue((new DocblockFieldValidator($emptyDocBlock->getDocComment(), $emptyDocBlock, $class))->isValidType(null));
+        $this->assertTrue((new DocblockFieldValidator($stringOrNull->getDocComment(), $stringOrNull, $class))->isValidType(null));
+        $this->assertTrue((new DocblockFieldValidator($null->getDocComment(), $null, $class))->isValidType(null));
+        $this->assertTrue((new DocblockFieldValidator($mixed->getDocComment(), $mixed, $class))->isValidType(null));
+        $this->assertTrue((new DocblockFieldValidator($nullableString->getDocComment(), $nullableString, $class))->isValidType(null));
     }
 
     /** @test */
     public function arrays_types_are_validated()
     {
-        $this->assertTrue((new DocblockFieldValidator('/** @var string[] */'))->isValidType(['a']));
-        $this->assertTrue((new DocblockFieldValidator('/** @var iterable<string> */'))->isValidType(['a']));
+        [$class, $stringArray, $stringIterable] = $this->getClassAndProperties(new class() {
+            /** @var string[] */
+            public $stringArray;
+            /** @var iterable<string> */
+            public $stringIterable;
+        });
 
-        $this->assertFalse((new DocblockFieldValidator('/** @var string[] */'))->isValidType([1]));
-        $this->assertFalse((new DocblockFieldValidator('/** @var string[] */'))->isValidType('a'));
+        $this->assertTrue((new DocblockFieldValidator($stringArray->getDocComment(), $stringArray, $class))->isValidType(['a']));
+        $this->assertTrue((new DocblockFieldValidator($stringIterable->getDocComment(), $stringIterable, $class))->isValidType(['a']));
+
+        $this->assertFalse((new DocblockFieldValidator($stringArray->getDocComment(), $stringArray, $class))->isValidType([1]));
+        $this->assertFalse((new DocblockFieldValidator($stringArray->getDocComment(), $stringArray, $class))->isValidType('a'));
     }
 
     /** @test */
     public function any_type_of_array_or_iterable_is_allowed()
     {
-        $this->assertTrue((new DocblockFieldValidator('/** @var array */'))->isValidType(['a', 1]));
-        $this->assertTrue((new DocblockFieldValidator('/** @var iterable */'))->isValidType(['a', 1]));
+        [$class, $array, $iterable, $stringArray, $stringIterable] = $this->getClassAndProperties(new class() {
+            /** @var array */
+            public $array;
+            /** @var iterable */
+            public $iterable;
+            /** @var string[] */
+            public $stringArray;
+            /** @var iterable<string> */
+            public $stringIterable;
+        });
 
-        $this->assertFalse((new DocblockFieldValidator('/** @var string[] */'))->isValidType(['a', 1]));
-        $this->assertFalse((new DocblockFieldValidator('/** @var iterable<string> */'))->isValidType(['a', 1]));
-        $this->assertFalse((new DocblockFieldValidator('/** @var string[] */'))->isValidType(['a', 1]));
+        $this->assertTrue((new DocblockFieldValidator($array->getDocComment(), $array, $class))->isValidType(['a', 1]));
+        $this->assertTrue((new DocblockFieldValidator($iterable->getDocComment(), $iterable, $class))->isValidType(['a', 1]));
+
+        $this->assertFalse((new DocblockFieldValidator($stringArray->getDocComment(), $stringArray, $class))->isValidType(['a', 1]));
+        $this->assertFalse((new DocblockFieldValidator($stringIterable->getDocComment(), $stringIterable, $class))->isValidType(['a', 1]));
+        $this->assertFalse((new DocblockFieldValidator($stringArray->getDocComment(), $stringArray, $class))->isValidType(['a', 1]));
     }
 
     /** @test */
     public function types_are_validated()
     {
-        $this->assertTrue((new DocblockFieldValidator('/** @var string */'))->isValidType('a'));
-        $this->assertTrue((new DocblockFieldValidator('/** @var float */'))->isValidType(1.0));
-        $this->assertTrue((new DocblockFieldValidator('/** @var int */'))->isValidType(1));
-        $this->assertTrue((new DocblockFieldValidator('/** @var int|float */'))->isValidType(1));
-        $this->assertTrue((new DocblockFieldValidator('/** @var int|float */'))->isValidType(1.0));
-        $this->assertTrue((new DocblockFieldValidator('/** @var int|string */'))->isValidType(1));
-        $this->assertTrue((new DocblockFieldValidator('/** @var int|string */'))->isValidType('a'));
-        $this->assertTrue((new DocblockFieldValidator('/** @var string|null */'))->isValidType('a'));
-        $this->assertTrue((new DocblockFieldValidator('/** @var \Spatie\DataTransferObject\Tests\Foo */'))->isValidType(new Foo));
-        $this->assertTrue((new DocblockFieldValidator('/** @var \Spatie\DataTransferObject\Tests\Foo */'))->isValidType(new FooChild));
+        [$class, $string, $float, $int, $intOrFloat, $intOrString, $stringOrNull, $foo] = $this->getClassAndProperties(new class() {
+            /** @var string */
+            public $string;
+            /** @var float */
+            public $float;
+            /** @var int */
+            public $int;
+            /** @var int|float */
+            public $intOrFloat;
+            /** @var int|string */
+            public $intOrString;
+            /** @var string|null */
+            public $stringOrNull;
+            /** @var \Spatie\DataTransferObject\Tests\Foo */
+            public $foo;
+        });
 
-        $this->assertFalse((new DocblockFieldValidator('/** @var string */'))->isValidType(1));
-        $this->assertFalse((new DocblockFieldValidator('/** @var \Spatie\DataTransferObject\Tests\Foo */'))->isValidType(new Bar));
+        $this->assertTrue((new DocblockFieldValidator($string->getDocComment(), $string, $class))->isValidType('a'));
+        $this->assertTrue((new DocblockFieldValidator($float->getDocComment(), $float, $class))->isValidType(1.0));
+        $this->assertTrue((new DocblockFieldValidator($int->getDocComment(), $int, $class))->isValidType(1));
+        $this->assertTrue((new DocblockFieldValidator($intOrFloat->getDocComment(), $intOrFloat, $class))->isValidType(1));
+        $this->assertTrue((new DocblockFieldValidator($intOrFloat->getDocComment(), $intOrFloat, $class))->isValidType(1.0));
+        $this->assertTrue((new DocblockFieldValidator($intOrString->getDocComment(), $intOrString, $class))->isValidType(1));
+        $this->assertTrue((new DocblockFieldValidator($intOrString->getDocComment(), $intOrString, $class))->isValidType('a'));
+        $this->assertTrue((new DocblockFieldValidator($stringOrNull->getDocComment(), $stringOrNull, $class))->isValidType('a'));
+        $this->assertTrue((new DocblockFieldValidator($foo->getDocComment(), $foo, $class))->isValidType(new Foo));
+        $this->assertTrue((new DocblockFieldValidator($foo->getDocComment(), $foo, $class))->isValidType(new FooChild));
+
+        $this->assertFalse((new DocblockFieldValidator($string->getDocComment(), $string, $class))->isValidType(1));
+        $this->assertFalse((new DocblockFieldValidator($foo->getDocComment(), $foo, $class))->isValidType(new Bar));
+    }
+
+    /** @test */
+    public function self_and_static_types_are_expanded()
+    {
+        [$class, $self, $static, $selfArray, $staticArray] = $this->getClassAndProperties(new FooChild);
+
+        $this->assertEquals([Foo::class], (new DocblockFieldValidator($self->getDocComment(), $self, $class))->allowedTypes);
+        $this->assertTrue((new DocblockFieldValidator($self->getDocComment(), $self, $class))->isValidType(new FooChild));
+        $this->assertTrue((new DocblockFieldValidator($self->getDocComment(), $self, $class))->isValidType(new Foo));
+        $this->assertFalse((new DocblockFieldValidator($self->getDocComment(), $self, $class))->isValidType(new Bar));
+
+        $this->assertEquals([FooChild::class], (new DocblockFieldValidator($static->getDocComment(), $static, $class))->allowedTypes);
+        $this->assertTrue((new DocblockFieldValidator($static->getDocComment(), $static, $class))->isValidType(new FooChild));
+        $this->assertFalse((new DocblockFieldValidator($static->getDocComment(), $static, $class))->isValidType(new Foo));
+        $this->assertFalse((new DocblockFieldValidator($static->getDocComment(), $static, $class))->isValidType(new Bar));
+
+        $this->assertEquals([Foo::class], (new DocblockFieldValidator($selfArray->getDocComment(), $static, $class))->allowedArrayTypes);
+        $this->assertTrue((new DocblockFieldValidator($selfArray->getDocComment(), $selfArray, $class))->isValidType([new FooChild]));
+        $this->assertTrue((new DocblockFieldValidator($selfArray->getDocComment(), $selfArray, $class))->isValidType([new Foo]));
+        $this->assertFalse((new DocblockFieldValidator($selfArray->getDocComment(), $selfArray, $class))->isValidType([new Bar]));
+
+        $this->assertEquals([FooChild::class], (new DocblockFieldValidator($staticArray->getDocComment(), $static, $class))->allowedArrayTypes);
+        $this->assertTrue((new DocblockFieldValidator($staticArray->getDocComment(), $staticArray, $class))->isValidType([new FooChild]));
+        $this->assertFalse((new DocblockFieldValidator($staticArray->getDocComment(), $staticArray, $class))->isValidType([new Foo]));
+        $this->assertFalse((new DocblockFieldValidator($staticArray->getDocComment(), $staticArray, $class))->isValidType([new Bar]));
+    }
+
+    private function getClassAndProperties(object $class): array
+    {
+        $reflectionClass = new ReflectionClass($class);
+
+        return [$reflectionClass, ...$reflectionClass->getProperties()];
     }
 }

--- a/tests/TestClasses/SelfDataTransferObject.php
+++ b/tests/TestClasses/SelfDataTransferObject.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests\TestClasses;
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class SelfDataTransferObject extends DataTransferObject
+{
+    /** @var self|null */
+    public $self;
+
+    /** @var string */
+    public $name;
+}

--- a/tests/TestClasses/SelfExtensionDataTransferObject.php
+++ b/tests/TestClasses/SelfExtensionDataTransferObject.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests\TestClasses;
+
+class SelfExtensionDataTransferObject extends SelfDataTransferObject
+{
+    //
+}

--- a/tests/TestClasses/StaticDataTransferObject.php
+++ b/tests/TestClasses/StaticDataTransferObject.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests\TestClasses;
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class StaticDataTransferObject extends DataTransferObject
+{
+    /** @var static|null */
+    public $static;
+
+    /** @var string */
+    public $name;
+}

--- a/tests/TestClasses/StaticExtensionDataTransferObject.php
+++ b/tests/TestClasses/StaticExtensionDataTransferObject.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests\TestClasses;
+
+class StaticExtensionDataTransferObject extends StaticDataTransferObject
+{
+    //
+}


### PR DESCRIPTION
see #111

This adds support for `static` and `self` type declarations. `self` accepts any instance or extension of the class in which it is _defined_. `static` accepts any instance or extension of the class in which it is _called_. When resolving from an array, `self` is always resolved to an instance of the class in which it is defined. `static` is resolved to an instance of the class in which it is called.

Unfortunately, whilst the change in functionality is small, the code base change is large since implementations of `FieldValidator` must now _always_ have information about the property and class instance.

I'm happy to make any changes upon request 👍