### PR TITLE
Collect invalid type errors instead of stopping at the first

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -46,6 +46,9 @@ abstract class DataTransferObject
 
         $valueCaster = $this->getValueCaster();
 
+        /** string[] */
+        $invalidTypes = [];
+
         foreach ($validators as $field => $validator) {
             if (
                 ! isset($parameters[$field])
@@ -63,17 +66,23 @@ abstract class DataTransferObject
             $value = $this->castValue($valueCaster, $validator, $value);
 
             if (! $validator->isValidType($value)) {
-                throw DataTransferObjectError::invalidType(
+                $invalidTypes[] = DataTransferObjectError::invalidTypeMessage(
                     static::class,
                     $field,
                     $validator->allowedTypes,
                     $value
                 );
+
+                continue;
             }
 
             $this->{$field} = $value;
 
             unset($parameters[$field]);
+        }
+
+        if ($invalidTypes) {
+            DataTransferObjectError::invalidTypes($invalidTypes);
         }
 
         if (! $this->ignoreMissing && count($parameters)) {

--- a/src/DataTransferObjectError.php
+++ b/src/DataTransferObjectError.php
@@ -15,12 +15,21 @@ class DataTransferObjectError extends TypeError
         return new self("Public properties `{$propertyNames}` not found on {$className}");
     }
 
-    public static function invalidType(
+    public static function invalidTypes(array $invalidTypes): DataTransferObjectError
+    {
+        $msg = count($invalidTypes) > 1
+            ? "The following invalid types were encountered:\n" . implode("\n", $invalidTypes) . "\n"
+            : "Invalid type: {$invalidTypes[0]}.";
+
+        throw new self($msg);
+    }
+
+    public static function invalidTypeMessage(
         string $class,
         string $field,
         array $expectedTypes,
         $value
-    ): DataTransferObjectError {
+    ): string {
         $currentType = gettype($value);
 
         if ($value === null) {
@@ -37,7 +46,7 @@ class DataTransferObjectError extends TypeError
 
         $expectedTypes = implode(', ', $expectedTypes);
 
-        return new self("Invalid type: expected `{$class}::{$field}` to be of type `{$expectedTypes}`, instead got value `{$value}`, which is {$currentType}.");
+        return "expected `{$class}::{$field}` to be of type `{$expectedTypes}`, instead got value `{$value}`, which is {$currentType}";
     }
 
     public static function uninitialized(string $class, string $field): DataTransferObjectError

--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -501,4 +501,33 @@ class DataTransferObjectTest extends TestCase
 
         $this->assertSame($expected, $object->all());
     }
+
+    /** @test */
+    public function multiple_required_properties_are_reported()
+    {
+        $exception = null;
+
+        try {
+            new class() extends DataTransferObject {
+                public string $i_am_required;
+                public int $so_am_i;
+            };
+        } catch (DataTransferObjectError $exception) {
+            // Deliberately empty
+        }
+
+        $this->assertInstanceOf(DataTransferObjectError::class, $exception);
+        
+        $actual = $exception->getMessage();
+        $actual = preg_replace('/anonymous.*:/', 'anonymous:', $actual);
+
+        $expected = <<<EXPECTED
+The following invalid types were encountered:
+expected `class@anonymous:i_am_required` to be of type `string`, instead got value `null`, which is NULL
+expected `class@anonymous:so_am_i` to be of type `integer`, instead got value `null`, which is NULL
+
+EXPECTED;
+
+        $this->assertSame($expected, $actual);
+    }
 }


### PR DESCRIPTION
## Summary
I deal with a lot of bigger DTOs, lots of properties. Invalid payloads
happen all the time but it's annoying to only always get the first
invalid type reported when they're more to wait.

This PR will not change single invalid type reporting but will support
multiple lines:
```
Spatie\DataTransferObject\DataTransferObjectError : The following invalid types were encountered:
expected `App\Services\DTO\Article::title` to be of type `string`, instead got value `null`, which is NULL
expected `App\Services\DTO\Article::created_at` to be of type `Carbon\CarbonImmutable`, instead got value `null`, which is NULL
```

Before finishing this (see below for TODO) I first want to know if @brendt wants to accept this?

### TODO
- [x] Move `\Spatie\DataTransferObject\DataTransferObjectError::invalidTypeMessage` out of the exception
- [x] Add tests for new behaviour