### PR TITLE
Add extension for PHPStan to support checkUninitializedProperties

### DIFF
--- a/.github/workflows/phpstan-extension.yml
+++ b/.github/workflows/phpstan-extension.yml
@@ -1,0 +1,31 @@
+name: Test PHPStan extension
+
+on: [push]
+
+jobs:
+  phpstan-extension:
+    runs-on: ubuntu-latest
+    env:
+        COMPOSER_NO_INTERACTION: 1
+
+    steps:
+      -   name: Checkout code
+          uses: actions/checkout@v2
+
+      -   name: Setup PHP
+          uses: shivammathur/setup-php@v2
+          with:
+            tool: composer:v2
+            coverage: none
+
+      -   name: Install dependencies
+          run: |
+            composer update --no-progress
+            composer require phpstan/phpstan --no-progress
+
+      -   name: Run PHPStan with extension
+          run:  vendor/bin/phpstan analyse --configuration=tests/PHPStan/phpstan-with-extension.neon
+
+      # This simply ensures that in case the extension is not enabled, the expected PHPStan error is really triggered
+      -   name: Run PHPStan without extension
+          run:  vendor/bin/phpstan analyse --configuration=tests/PHPStan/phpstan-without-extension.neon 2>&1 | grep 'has an uninitialized property'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `data-transfer-object` will be documented in this file
 
+## Unreleased
+- Add PHPStan extension to support `checkUninitializedProperties: true`
+
 ## 2.2.1 - 2020-05-13
 
 - Validator for typed 7.4 properties (#109)

--- a/README.md
+++ b/README.md
@@ -422,6 +422,22 @@ $dto = new PostData([
 $dto->toArray(); // ['content' => 'blah blah']
 ```
 
+### PHPStan
+
+If you're using [phpstan](https://phpstan.org/) and set `checkUninitializedProperties: true`, phpstan by default doesn't understand that the DTO properties will always be correctly initialized.
+
+To help with that, this package provides a rule you can add to your `.neon` config file:
+```yaml
+services:
+  -
+    class: Spatie\DataTransferObject\PHPstan\PropertiesAreAlwaysInitializedExtension
+    tags:
+      - phpstan.properties.readWriteExtension
+#…
+parameters:
+  checkUninitializedProperties: true
+```
+
 ### Testing
 
 ``` bash

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
         "larapack/dd": "^1.0",
         "phpunit/phpunit": "^7.0"
     },
+    "suggest": {
+        "phpstan/phpstan": "Take advantage of checkUninitializedProperties with \\Spatie\\DataTransferObject\\PHPstan\\PropertiesAreAlwaysInitializedExtension"
+    },
     "autoload": {
         "psr-4": {
             "Spatie\\DataTransferObject\\": "src"

--- a/src/PHPstan/PropertiesAreAlwaysInitializedExtension.php
+++ b/src/PHPstan/PropertiesAreAlwaysInitializedExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\PHPstan;
+
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\Rules\Properties\ReadWritePropertiesExtension;
+use Spatie\DataTransferObject\DataTransferObject;
+
+class PropertiesAreAlwaysInitializedExtension implements ReadWritePropertiesExtension
+{
+    public function isAlwaysRead(PropertyReflection $property, string $propertyName): bool
+    {
+        return false;
+    }
+
+    public function isAlwaysWritten(PropertyReflection $property, string $propertyName): bool
+    {
+        return false;
+    }
+
+    public function isInitialized(PropertyReflection $property, string $propertyName): bool
+    {
+        return $property->getDeclaringClass()->isSubclassOf(DataTransferObject::class);
+    }
+}

--- a/tests/PHPStan/ExampleDTO.php
+++ b/tests/PHPStan/ExampleDTO.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests\PHPStan;
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class ExampleDTO extends DataTransferObject
+{
+    public int $id;
+}
+
+$dto = new ExampleDTO(['id' => 1]);
+echo $dto->id, "\n";

--- a/tests/PHPStan/phpstan-with-extension.neon
+++ b/tests/PHPStan/phpstan-with-extension.neon
@@ -1,0 +1,10 @@
+services:
+  -
+    class: Spatie\DataTransferObject\PHPstan\PropertiesAreAlwaysInitializedExtension
+    tags:
+      - phpstan.properties.readWriteExtension
+parameters:
+    paths:
+      - .
+    level: 0
+    checkUninitializedProperties: true

--- a/tests/PHPStan/phpstan-without-extension.neon
+++ b/tests/PHPStan/phpstan-without-extension.neon
@@ -1,0 +1,5 @@
+parameters:
+    paths:
+      - .
+    level: 0
+    checkUninitializedProperties: true


### PR DESCRIPTION
## Summary
Please read the discussion in https://github.com/spatie/data-transfer-object/issues/129 first.

I decided to go ahead and suggest a simple inclusion of the PHPStan extension for now instead of separate repo to avoid the overhead of managing a dedicate package for a few lines of code.

The idea is:
- the extension installed
- phpstan is suggested for composer
- end users can enable the extension manually with this neon configuration
  ```neon
  services:
    -
      class: Spatie\DataTransferObject\PHPstan\PropertiesAreAlwaysInitializedExtension
      tags:
        - phpstan.properties.readWriteExtension
  ```

Tests are added with a dedicated workflow:
- installs phpstan (just the latest version for now)
- runs a positive and a negative test, i.e. ensures that activating/absence of the extension works correctly.

Ad github action: I decided now to cache composer but use `composer:v2` instead. In my tests, due to parallel downloads, it was as fast as the v1 with cache or very close.

### Links
- Fixes https://github.com/spatie/data-transfer-object/issues/129