### PR TITLE
Use fromRequest method if exists in nested DTOs.

### DIFF
--- a/src/ValueCaster.php
+++ b/src/ValueCaster.php
@@ -29,7 +29,9 @@ class ValueCaster
             return $value;
         }
 
-        return new $castTo($value);
+        return (method_exists($castTo, 'fromRequest'))
+            ? $castTo::fromRequest($value)
+            : new $castTo($value);
     }
 
     public function castCollection($values, array $allowedArrayTypes)
@@ -52,7 +54,15 @@ class ValueCaster
 
         $casts = [];
 
+        $use_fromRequest = method_exists($castTo, 'fromRequest');
+
         foreach ($values as $value) {
+            if ($use_fromRequest) {
+                $casts[] = $castTo::fromRequest($value);
+
+                continue;
+            }
+
             $casts[] = new $castTo($value);
         }
 

--- a/tests/NestedFormattedChildTest.php
+++ b/tests/NestedFormattedChildTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests;
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class NestedFormattedChildTest extends TestCase
+{
+    /** @test */
+    public function it_use_fromRequest_method()
+    {
+        $a = new NestedParentFormattedChild([
+            'name' => 'parent',
+            'child' => [
+                'name' => 'child',
+            ],
+        ]);
+
+        $this->assertEquals('CHILD', $a->child->name);
+    }
+}
+
+class NestedParentFormattedChild extends DataTransferObject
+{
+    /** @var \Spatie\DataTransferObject\Tests\TestClasses\NestedFormattedChild */
+    public $child;
+
+    /** @var string */
+    public $name;
+}

--- a/tests/NestedManyFormattedChildrenTest.php
+++ b/tests/NestedManyFormattedChildrenTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests;
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class NestedManyFormattedChildrenTest extends TestCase
+{
+    /** @test */
+    public function it_use_fromRequest_method()
+    {
+        $a = new NestedParentOfManyFormatted([
+            'name' => 'parent',
+            'children' => [
+                ['name' => 'child_1'],
+                ['name' => 'child_2'],
+            ],
+        ]);
+
+        $this->assertEquals('CHILD_1', $a->children[0]->name);
+    }
+}
+
+class NestedParentOfManyFormatted extends DataTransferObject
+{
+    /** @var \Spatie\DataTransferObject\Tests\TestClasses\NestedFormattedChild[] */
+    public $children;
+
+    /** @var string */
+    public $name;
+}

--- a/tests/TestClasses/NestedFormattedChild.php
+++ b/tests/TestClasses/NestedFormattedChild.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests\TestClasses;
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class NestedFormattedChild extends DataTransferObject
+{
+    /** @var string */
+    public $name;
+
+    public static function fromRequest($data): self
+    {
+        return new self([
+            'name' => strtoupper($data['name']),
+        ]);
+    }
+}


### PR DESCRIPTION
Hi,

I open this PR because I had issue with nested DTOs, that I can't format income data using `fromRequest`. ex:
```php
class Category extends DataTransferObject
{
    /** @var string */
    public $name;

    /** @var \Bla\To\Product */
    public $product;
}

class Product extends DataTransferObject
{
    /** @var string */
    public $name;

    /** @var \Carbon\Carbon */
    public $expiration;

    public static function fromRequest($data): self
    {
        return new self([
            'name'      => $data['name'],
           'expiration' => Carbon::parse($data['expiration'])
        ]);
    }
}

$category_dto = new Category([
    'name' => 'bla',
    'product' => [
        'name' => 'product',
        'expiration' => '2020-09-02 12:22' // this will give an error
    ],
]);
```

for this issue I opened this PR to solve this problem, now if it find `fromRequest` it will use it, instead of create new object and pass data to constructor directly