### PR TITLE
Override protected attributes

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -9,8 +9,6 @@ use ReflectionProperty;
 
 abstract class DataTransferObject
 {
-    protected bool $ignoreMissing = false;
-
     protected array $exceptKeys = [];
 
     protected array $onlyKeys = [];
@@ -85,9 +83,14 @@ abstract class DataTransferObject
             DataTransferObjectError::invalidTypes($invalidTypes);
         }
 
-        if (! $this->ignoreMissing && count($parameters)) {
+        if (! $this->ignoreMissing() && count($parameters)) {
             throw DataTransferObjectError::unknownProperties(array_keys($parameters), static::class);
         }
+    }
+
+    protected function ignoreMissing(): bool
+    {
+        return false;
     }
 
     public function all(): array

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -9,10 +9,6 @@ use ReflectionProperty;
 
 abstract class DataTransferObject
 {
-    protected array $exceptKeys = [];
-
-    protected array $onlyKeys = [];
-
     /**
      * @param array $parameters
      *
@@ -113,45 +109,19 @@ abstract class DataTransferObject
         return $data;
     }
 
-    /**
-     * @param string ...$keys
-     *
-     * @return static
-     */
-    public function only(string ...$keys): DataTransferObject
+    public function only(string ...$keys): DataTransferObjectArray
     {
-        $dataTransferObject = clone $this;
-
-        $dataTransferObject->onlyKeys = [...$this->onlyKeys, ...$keys];
-
-        return $dataTransferObject;
+        return new DataTransferObjectArray(Arr::only($this->toArray(), $keys));
     }
 
-    /**
-     * @param string ...$keys
-     *
-     * @return static
-     */
-    public function except(string ...$keys): DataTransferObject
+    public function except(string ...$keys): DataTransferObjectArray
     {
-        $dataTransferObject = clone $this;
-
-        $dataTransferObject->exceptKeys = [...$this->exceptKeys, ...$keys];
-
-        return $dataTransferObject;
+        return new DataTransferObjectArray(Arr::except($this->toArray(), $keys));
     }
 
     public function toArray(): array
     {
-        if (count($this->onlyKeys)) {
-            $array = Arr::only($this->all(), $this->onlyKeys);
-        } else {
-            $array = Arr::except($this->all(), $this->exceptKeys);
-        }
-
-        $array = $this->parseArray($array);
-
-        return $array;
+        return $this->parseArray($this->all());
     }
 
     protected function parseArray(array $array): array

--- a/src/DataTransferObjectArray.php
+++ b/src/DataTransferObjectArray.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Spatie\DataTransferObject;
+
+class DataTransferObjectArray
+{
+    private array $attributes;
+
+    public function __construct(array $attributes = [])
+    {
+        $this->attributes = $attributes;
+    }
+
+    public function only(string ...$keys): DataTransferObjectArray
+    {
+        return new DataTransferObjectArray(Arr::only($this->attributes, $keys));
+    }
+
+    public function except(string ...$keys): DataTransferObjectArray
+    {
+        return new DataTransferObjectArray(Arr::except($this->attributes, $keys));
+    }
+
+    public function toArray(): array
+    {
+        return $this->attributes;
+    }
+}

--- a/src/FlexibleDataTransferObject.php
+++ b/src/FlexibleDataTransferObject.php
@@ -4,5 +4,8 @@ namespace Spatie\DataTransferObject;
 
 abstract class FlexibleDataTransferObject extends DataTransferObject
 {
-    protected bool $ignoreMissing = true;
+    protected function ignoreMissing(): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
Hi guys,

If I understand correctly, I can't add some field names to my DTO class to use them when parsing some data. These are protected fields that are declared in the parent `DataTransferObject` class. For example, `ignoreMissing`, `exceptKeys`, and `onlyKeys`.

```php
use Spatie\DataTransferObject\DataTransferObject;

class PostData extends DataTransferObject
{
    public int $ignoreMissing;
    
    public bool $onlyKeys;
}
```

I also noticed that the `except()` and `only()` methods are mainly used in combination with the `toArray()` method, since these methods only affect the list of keys when exporting to an array, perhaps we can transfer such methods to a separate class and also use a chain of method calls.

Thank you for your attention.