### PR TITLE
Adds Data Transfer Object Factory to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ We publish all received postcards [on our company website](https://spatie.be/en/
 ## External tools
 
 - [json2dto](https://json2dto.atymic.dev): a GUI to convert JSON objects to DTO classes (with nesting support). Also provides a [CLI tool](https://github.com/atymic/json2dto#cli-tool) for local usage.
+- [Data Transfer Object Factory](https://github.com/anteris-dev/data-transfer-object-factory): generates a DTO instance or collection with fake data based on its definition. Supports type casting and doc blocks.
 
 ## Credits
 


### PR DESCRIPTION
Closes #148 by adding a reference to the Data Transfer Object Factory package in the external tools section.