### PR TITLE
Any object that has a callable toArray() should be parsed as array

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -154,10 +154,7 @@ abstract class DataTransferObject
     protected function parseArray(array $array): array
     {
         foreach ($array as $key => $value) {
-            if (
-                $value instanceof DataTransferObject
-                || $value instanceof DataTransferObjectCollection
-            ) {
+            if (is_object($value) && is_callable([$value, 'toArray'])) {
                 $array[$key] = $value->toArray();
 
                 continue;

--- a/src/DataTransferObjectCollection.php
+++ b/src/DataTransferObjectCollection.php
@@ -76,10 +76,7 @@ abstract class DataTransferObjectCollection implements
         $collection = $this->collection;
 
         foreach ($collection as $key => $item) {
-            if (
-                ! $item instanceof DataTransferObject
-                && ! $item instanceof DataTransferObjectCollection
-            ) {
+            if (is_object($item) === false || is_callable([$item, 'toArray']) === false) {
                 continue;
             }
 


### PR DESCRIPTION
Not sure if this change follows the logic of this package but I like the package to be more flexible with accepting (nested) objects that should be parsed as arrays.

With this change an attribute can also be for example a Laravel Collection.

I would like to get some feedback and I'm happy to make changes if necessary.