### PR TITLE
Fix incorrect return type

### DIFF
--- a/src/FieldValidator.php
+++ b/src/FieldValidator.php
@@ -195,7 +195,7 @@ abstract class FieldValidator
         $type = $matches[1] ?? null;
 
         if (! $type) {
-            return null;
+            return [];
         }
 
         return explode('|', $type);


### PR DESCRIPTION
Return type should be an array (with data or empty) and not null.

See https://github.com/spatie/data-transfer-object/issues/163