### PR TITLE
Prevent DataTransferObjectCollection from iterating over array copy

### DIFF
--- a/src/DataTransferObjectCollection.php
+++ b/src/DataTransferObjectCollection.php
@@ -14,19 +14,16 @@ abstract class DataTransferObjectCollection implements
     Iterator,
     Countable
 {
-    protected array $collection;
-
-    protected ArrayIterator $iterator;
+    protected ArrayIterator $collection;
 
     public function __construct(array $collection = [])
     {
-        $this->collection = $collection;
-        $this->iterator = new ArrayIterator($this->collection);
+        $this->collection = new ArrayIterator($collection);
     }
 
     public function current()
     {
-        return $this->iterator->current();
+        return $this->collection->current();
     }
 
     public function offsetGet($offset)
@@ -55,32 +52,32 @@ abstract class DataTransferObjectCollection implements
 
     public function next()
     {
-        $this->iterator->next();
+        $this->collection->next();
     }
 
     public function key()
     {
-        return $this->iterator->key();
+        return $this->collection->key();
     }
 
     public function valid(): bool
     {
-        return $this->iterator->valid();
+        return $this->collection->valid();
     }
 
     public function rewind()
     {
-        $this->iterator->rewind();
+        $this->collection->rewind();
     }
 
     public function toArray(): array
     {
-        $collection = $this->collection;
+        $collection = $this->collection->getArrayCopy();
 
         foreach ($collection as $key => $item) {
             if (
-                ! $item instanceof DataTransferObject
-                && ! $item instanceof DataTransferObjectCollection
+                !$item instanceof DataTransferObject
+                && !$item instanceof DataTransferObjectCollection
             ) {
                 continue;
             }
@@ -93,7 +90,7 @@ abstract class DataTransferObjectCollection implements
 
     public function items(): array
     {
-        return $this->collection;
+        return $this->collection->getArrayCopy();
     }
 
     public function count(): int

--- a/tests/DataTransferObjectCollectionTest.php
+++ b/tests/DataTransferObjectCollectionTest.php
@@ -99,4 +99,23 @@ class DataTransferObjectCollectionTest extends TestCase
 
         $this->assertEquals(['a' => 1, 'b' => 2, 'c' => 3,], $traversed);
     }
+
+    /** @test */
+    public function it_iterates_over_up_to_date_collection(): void
+    {
+        $list = new class() extends DataTransferObjectCollection {
+        };
+
+        $list[] = new TestDataTransferObject(['testProperty' => 1]);
+        $list[] = new TestDataTransferObject(['testProperty' => 2]);
+        $list[] = new TestDataTransferObject(['testProperty' => 3]);
+
+        $traversed = [];
+
+        foreach ($list as $id => $item) {
+            $traversed[$id] = $item->testProperty;
+        }
+
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3,], $traversed);
+    }
 }


### PR DESCRIPTION
With the introduction of 2.8.0 (https://github.com/spatie/data-transfer-object/commit/88ffe870053853cb086d95a3549082e8b97e7cba) the `DataTransferObjectCollection` iterates over copy of the internal `$collection` array instead of over the current value of array itself.

This breaks backwards compatibility as demonstrated by the testcase below. Before 2.8.0, this test would pass and on 2.8.0 it fails.


```php
    public function test_it_iterates_over_internal_array(): void
    {
        $list = new class() extends DataTransferObjectCollection {
        };

        $list[] = new TestDataTransferObject(['testProperty' => 1]);
        $list[] = new TestDataTransferObject(['testProperty' => 2]);
        $list[] = new TestDataTransferObject(['testProperty' => 3]);

        $traversed = [];

        foreach ($list as $id => $item) {
            $traversed[$id] = $item->testProperty;
        }

        $this->assertEquals([0 => 1, 1 => 2, 2 => 3,], $traversed);
    }

// Actual yield: Array ()
// Expected yield: Array (0 => 1, 1 => 2, 2 => 3)
```

This PR is the **_simplest solution_** to make the above test pass, but also breaks backwards compatibility as it changes the type of the protected `$collection` field.

I think it is a design decision on which type of backwards compatibility to break, so I'm wondering about your opinion on this.
From one perspective it also makes some sense to have the collections Immutable (implicit), while on the other hand the current API is explicit about immutability for DTO's (non collections) already.

There are multiple ways to re-introduce the behavior described above, other that the proposed code:
1. Revert the associative collection support and go back to the previous way of iterating (not really moving forward)
2. Keep the `protected array $collection = [];` and create a new `ArrayIterator` every time the `offsetSet` method is called (prone to side-effects, resetting the iterator position)
3. Moving associative array support to a specialized concrete `DataTransferObjectAssociativeCollection`, removing the `ArrayIterator` from `DataTransferObjectCollection`, that class would probably also need # 2.