### PR TITLE
Fix cast with null

### DIFF
--- a/src/Reflection/DataTransferObjectProperty.php
+++ b/src/Reflection/DataTransferObjectProperty.php
@@ -37,7 +37,7 @@ class DataTransferObjectProperty
 
     public function setValue(mixed $value): void
     {
-        if ($this->caster) {
+        if ($this->caster && $value !== null) {
             $value = $this->caster->cast($value);
         }
 

--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -4,6 +4,7 @@ namespace Spatie\DataTransferObject\Tests;
 
 use Spatie\DataTransferObject\Tests\Dummy\BasicDto;
 use Spatie\DataTransferObject\Tests\Dummy\ComplexDto;
+use Spatie\DataTransferObject\Tests\Dummy\ComplexDtoWithNullableProperty;
 
 class DataTransferObjectTest extends TestCase
 {
@@ -33,6 +34,18 @@ class DataTransferObjectTest extends TestCase
 
         $this->assertEquals('a', $dto->name);
         $this->assertEquals('b', $dto->other->name);
+    }
+
+    /** @test */
+    public function create_with_null_nullable_nested_dto()
+    {
+        $dto = new ComplexDtoWithNullableProperty([
+            'name' => 'a',
+            'other' => null,
+        ]);
+
+        $this->assertEquals('a', $dto->name);
+        $this->assertNull($dto->other);
     }
 
     /** @test */

--- a/tests/Dummy/ComplexDtoWithNullableProperty.php
+++ b/tests/Dummy/ComplexDtoWithNullableProperty.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests\Dummy;
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class ComplexDtoWithNullableProperty extends DataTransferObject
+{
+    public string $name;
+
+    public ?BasicDto $other;
+}


### PR DESCRIPTION
Currently, a DTO like 
```php
class ComplexDtoWithNullableProperty extends DataTransferObject
{
    public string $name;

    public ?BasicDto $other;
}
```
cannot be created with
```php
new ComplexDtoWithNullableProperty(name: 'a', other: null)
```
because we are having a
```
TypeError: Only arrays and Traversables can be unpacked

vendor/spatie/data-transfer-object/src/Casters/DataTransferObjectCaster.php:17
vendor/spatie/data-transfer-object/src/Reflection/DataTransferObjectProperty.php:41
```

This PR fixes the issue applying the cast only when given value is not null.

