### PR TITLE
Give dto to caster

### DIFF
--- a/src/Casters/DataTransferObjectCaster.php
+++ b/src/Casters/DataTransferObjectCaster.php
@@ -14,6 +14,10 @@ class DataTransferObjectCaster implements Caster
 
     public function cast(mixed $value): DataTransferObject
     {
+        if ($value instanceof $this->className) {
+            return $value;
+        }
+
         return new $this->className(...$value);
     }
 }

--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\DataTransferObject\Tests;
 
+use Spatie\DataTransferObject\DataTransferObject;
 use Spatie\DataTransferObject\Tests\Dummy\BasicDto;
 use Spatie\DataTransferObject\Tests\Dummy\ComplexDto;
 use Spatie\DataTransferObject\Tests\Dummy\ComplexDtoWithNullableProperty;
@@ -30,6 +31,20 @@ class DataTransferObjectTest extends TestCase
             'other' => [
                 'name' => 'b',
             ],
+        ]);
+
+        $this->assertEquals('a', $dto->name);
+        $this->assertEquals('b', $dto->other->name);
+    }
+
+    /** @test */
+    public function create_with_nested_dto_already_casted()
+    {
+        $dto = new ComplexDto([
+            'name' => 'a',
+            'other' => new BasicDto([
+                'name' => 'b',
+            ]),
         ]);
 
         $this->assertEquals('a', $dto->name);


### PR DESCRIPTION
It is sometimes convenient to give an already created nested DTO to the parent DTO.

For example, if you want to map an api response which looks like 
```json
{  
  "product": "the product",
  "value": {
    "cents": 100,
    "sign": "€"      
  }
}
```
to
```php
class Product extends DataTransferObject {

    public string $label;
    public string $price;
    
    public static function fromApi(array $api) 
    {
        return new self([
            'label' => $api['product'], 
            'price' => Price::fromApi($api['value'])
        ]);
    }
}

class Price extends DataTransferObject {

    public int $amount;
    public string $currency;


   public static function fromApi(array $api) 
   {
        return new self([
            'amount' => $api['cents'],
            'currency' => $api['sign']
       ]);
    }
}
```
It is currently not possible as DataTransferObject will try to cast it as well.

~~This fix may be implemented upstream, directly in DataTransfertObjectProperty~~ Not sure about that
