### PR TITLE
Add jetbrains attributes package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     },
     "require-dev": {
         "larapack/dd": "^1.1",
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^9.0",
+        "jetbrains/phpstorm-attributes": "^1.0"
     },
     "suggest": {
         "phpstan/phpstan": "Take advantage of checkUninitializedProperties with \\Spatie\\DataTransferObject\\PHPstan\\PropertiesAreAlwaysInitializedExtension"


### PR DESCRIPTION
As the code is filled with JetBrains helper attributes like `#[Immutable]` now, it's best to include the package in `require-dev`. This will solve issues with other IDE's and self-sufficient.

https://packagist.org/packages/jetbrains/phpstorm-attributes
https://github.com/JetBrains/phpstorm-attributes