### PR TITLE
Fix union type casting

### DIFF
--- a/tests/UnionDtoTest.php
+++ b/tests/UnionDtoTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests;
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class UnionDtoTest extends TestCase
+{
+    /** @test */
+    public function union_types_are_allowed()
+    {
+        $dto = new UnionDto(foo: 1);
+
+        $this->assertEquals(1, $dto->foo);
+    }
+}
+
+class UnionDto extends DataTransferObject
+{
+    public string|int $foo;
+}


### PR DESCRIPTION
Right now properties with a union type are not supported because the `resolveCasterFromType` method in `DataTransferObjectProperty` class throw an exception in the `$type->getName()` call (The `getName` method does not exists in `ReflectionUnionType`.

I don't know if the solution I implemented is the best solution but in my tests it works.
