### PR TITLE
Resolve default cast from parent classes

### DIFF
--- a/src/Reflection/DataTransferObjectProperty.php
+++ b/src/Reflection/DataTransferObjectProperty.php
@@ -110,7 +110,15 @@ class DataTransferObjectProperty
 
     private function resolveCasterFromDefaults(): ?Caster
     {
-        $defaultCastAttributes = $this->reflectionProperty->getDeclaringClass()->getAttributes(DefaultCast::class);
+        $defaultCastAttributes = [];
+
+        $class = $this->reflectionProperty->getDeclaringClass();
+
+        do {
+            array_push($defaultCastAttributes, ...$class->getAttributes(DefaultCast::class));
+
+            $class = $class->getParentClass();
+        } while ($class !== false);
 
         if (! count($defaultCastAttributes)) {
             return null;

--- a/tests/DefaultCasterTest.php
+++ b/tests/DefaultCasterTest.php
@@ -17,10 +17,28 @@ class DefaultCasterTest extends TestCase
 
         $this->markTestSucceeded();
     }
+
+    /** @test */
+    public function child_property_is_casted()
+    {
+        $dto = new ChildDto(date: '2020-01-01');
+
+        $this->markTestSucceeded();
+    }
 }
 
 #[DefaultCast(DateTimeImmutable::class, DateTimeImmutableCaster::class)]
 class DtoWithDefaultCaster extends DataTransferObject
+{
+    public DateTimeImmutable $date;
+}
+
+#[DefaultCast(DateTimeImmutable::class, DateTimeImmutableCaster::class)]
+abstract class AbstractWithDefaultCaster extends DataTransferObject
+{
+}
+
+class ChildDto extends AbstractWithDefaultCaster
 {
     public DateTimeImmutable $date;
 }


### PR DESCRIPTION
Calling `getAttributes` on a class returns only attributes applied to that class and not those applied to the parent classes, so we need to cycle through the entire hierarchy to load default casts from parent classes.