### PR TITLE
Adds basic caching for reflection classes and properties.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `data-transfer-object` will be documented in this file
 
+## Unreleased
+
+- Support caching of reflection classes and properties (#190)
+
 ## 3.0.4 - 2021-04-14
 
 - Support union types (#185)

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     },
     "require-dev": {
         "illuminate/collections": "^8.36",
+        "jetbrains/phpstorm-attributes": "^1.0",
         "larapack/dd": "^1.1",
-        "phpunit/phpunit": "^9.0",
-        "jetbrains/phpstorm-attributes": "^1.0"
+        "phpunit/phpunit": "^9.0"
     },
     "suggest": {
         "phpstan/phpstan": "Take advantage of checkUninitializedProperties with \\Spatie\\DataTransferObject\\PHPstan\\PropertiesAreAlwaysInitializedExtension"

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -2,8 +2,6 @@
 
 namespace Spatie\DataTransferObject;
 
-use ReflectionClass;
-use ReflectionProperty;
 use Spatie\DataTransferObject\Attributes\CastWith;
 use Spatie\DataTransferObject\Casters\DataTransferObjectCaster;
 use Spatie\DataTransferObject\Exceptions\UnknownProperties;
@@ -49,16 +47,12 @@ abstract class DataTransferObject
     {
         $data = [];
 
-        $class = new ReflectionClass(static::class);
+        $class = new DataTransferObjectClass($this);
 
-        $properties = $class->getProperties(ReflectionProperty::IS_PUBLIC);
+        $properties = $class->getProperties();
 
         foreach ($properties as $property) {
-            if ($property->isStatic()) {
-                continue;
-            }
-
-            $data[$property->getName()] = $property->getValue($this);
+            $data[$property->name] = $property->getValue($this);
         }
 
         return $data;


### PR DESCRIPTION
This pull request adds support for "caching" of reflection classes and properties by storing them in static arrays keyed by the DTO FQDN.

This also modifies the `Spatie\DataTransferObject\DataTransferObject` class to use `Spatie\DataTransferObject\Reflection\DataTransferObjectClass` in the `all()` method as opposed to creating new reflection instances.

Closes #190 