### PR TITLE
Allow for DTO with optional parameters

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -28,10 +28,10 @@ abstract class DataTransferObject
             if (array_key_exists($property->name, $args)) {
                 $property->setValue($args[$property->name]);
                 unset($args[$property->name]);
-            } else {
-                if ($property->hasDefaultValue()) {
-                    $property->setValue($property->getDefaultValue());
-                }
+            } elseif ($property->hasDefaultValue()) {
+                $property->setValue($property->getDefaultValue());
+            } elseif (!$property->allowsNull()) {
+                throw new \InvalidArgumentException("No value provided for required property {$property->name}");
             }
         }
 

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -42,7 +42,7 @@ abstract class DataTransferObject
         $class->validate();
     }
 
-    public static function arrayOf(array $arrayOfParameters) : array
+    public static function arrayOf(array $arrayOfParameters): array
     {
         return array_map(
             fn (mixed $parameters) => new static($parameters),
@@ -50,7 +50,7 @@ abstract class DataTransferObject
         );
     }
 
-    public function all() : array
+    public function all(): array
     {
         $data = [];
 
@@ -73,7 +73,7 @@ abstract class DataTransferObject
         return $data;
     }
 
-    public function only(string ...$keys) : static
+    public function only(string ...$keys): static
     {
         $dataTransferObject = clone $this;
 
@@ -82,7 +82,7 @@ abstract class DataTransferObject
         return $dataTransferObject;
     }
 
-    public function except(string ...$keys) : static
+    public function except(string ...$keys): static
     {
         $dataTransferObject = clone $this;
 
@@ -91,12 +91,12 @@ abstract class DataTransferObject
         return $dataTransferObject;
     }
 
-    public function clone(...$args) : static
+    public function clone(...$args): static
     {
         return new static(...array_merge($this->toArray(), $args));
     }
 
-    public function toArray() : array
+    public function toArray(): array
     {
         if (count($this->onlyKeys)) {
             $array = Arr::only($this->all(), $this->onlyKeys);
@@ -109,7 +109,7 @@ abstract class DataTransferObject
         return $array;
     }
 
-    protected function parseArray(array $array) : array
+    protected function parseArray(array $array): array
     {
         foreach ($array as $key => $value) {
             if ($value instanceof DataTransferObject) {

--- a/src/Reflection/DataTransferObjectProperty.php
+++ b/src/Reflection/DataTransferObjectProperty.php
@@ -77,6 +77,23 @@ class DataTransferObjectProperty
         return $this->reflectionProperty->getDefaultValue();
     }
 
+    public function allowsNull() : bool
+    {
+        $type = $this->reflectionProperty->getType();
+
+        if ($type instanceof \ReflectionUnionType) {
+            return count(array_filter($type->getTypes(), function($type){
+                return $type->allowsNull();
+            })) > 0;
+        }
+
+        if ($type instanceof \ReflectionNamedType) {
+            return $type->allowsNull();
+        }
+
+        throw new \UnexpectedValueException("Unhandled property type");
+    }
+
     private function resolveCaster(): ?Caster
     {
         $attributes = $this->reflectionProperty->getAttributes(CastWith::class);

--- a/src/Reflection/DataTransferObjectProperty.php
+++ b/src/Reflection/DataTransferObjectProperty.php
@@ -37,7 +37,7 @@ class DataTransferObjectProperty
         $this->caster = $this->resolveCaster();
     }
 
-    public function setValue(mixed $value) : void
+    public function setValue(mixed $value): void
     {
         if ($this->caster && $value !== null) {
             $value = $this->caster->cast($value);
@@ -49,7 +49,7 @@ class DataTransferObjectProperty
     /**
      * @return \Spatie\DataTransferObject\Validator[]
      */
-    public function getValidators() : array
+    public function getValidators(): array
     {
         $attributes = $this->reflectionProperty->getAttributes(
             Validator::class,
@@ -62,22 +62,22 @@ class DataTransferObjectProperty
         );
     }
 
-    public function getValue() : mixed
+    public function getValue(): mixed
     {
         return $this->reflectionProperty->getValue($this->dataTransferObject);
     }
 
-    public function hasDefaultValue() : bool
+    public function hasDefaultValue(): bool
     {
         return $this->reflectionProperty->hasDefaultValue();
     }
 
-    public function getDefaultValue() : mixed
+    public function getDefaultValue(): mixed
     {
         return $this->reflectionProperty->getDefaultValue();
     }
 
-    private function resolveCaster() : ?Caster
+    private function resolveCaster(): ?Caster
     {
         $attributes = $this->reflectionProperty->getAttributes(CastWith::class);
 
@@ -97,7 +97,7 @@ class DataTransferObjectProperty
         );
     }
 
-    private function resolveCasterFromType() : array
+    private function resolveCasterFromType(): array
     {
         $type = $this->reflectionProperty->getType();
 
@@ -132,7 +132,7 @@ class DataTransferObjectProperty
         return [];
     }
 
-    private function resolveCasterFromDefaults() : ?Caster
+    private function resolveCasterFromDefaults(): ?Caster
     {
         $defaultCastAttributes = [];
 

--- a/src/Reflection/DataTransferObjectProperty.php
+++ b/src/Reflection/DataTransferObjectProperty.php
@@ -37,7 +37,7 @@ class DataTransferObjectProperty
         $this->caster = $this->resolveCaster();
     }
 
-    public function setValue(mixed $value): void
+    public function setValue(mixed $value) : void
     {
         if ($this->caster && $value !== null) {
             $value = $this->caster->cast($value);
@@ -49,7 +49,7 @@ class DataTransferObjectProperty
     /**
      * @return \Spatie\DataTransferObject\Validator[]
      */
-    public function getValidators(): array
+    public function getValidators() : array
     {
         $attributes = $this->reflectionProperty->getAttributes(
             Validator::class,
@@ -62,12 +62,22 @@ class DataTransferObjectProperty
         );
     }
 
-    public function getValue(): mixed
+    public function getValue() : mixed
     {
         return $this->reflectionProperty->getValue($this->dataTransferObject);
     }
 
-    private function resolveCaster(): ?Caster
+    public function hasDefaultValue() : bool
+    {
+        return $this->reflectionProperty->hasDefaultValue();
+    }
+
+    public function getDefaultValue() : mixed
+    {
+        return $this->reflectionProperty->getDefaultValue();
+    }
+
+    private function resolveCaster() : ?Caster
     {
         $attributes = $this->reflectionProperty->getAttributes(CastWith::class);
 
@@ -87,7 +97,7 @@ class DataTransferObjectProperty
         );
     }
 
-    private function resolveCasterFromType(): array
+    private function resolveCasterFromType() : array
     {
         $type = $this->reflectionProperty->getType();
 
@@ -122,7 +132,7 @@ class DataTransferObjectProperty
         return [];
     }
 
-    private function resolveCasterFromDefaults(): ?Caster
+    private function resolveCasterFromDefaults() : ?Caster
     {
         $defaultCastAttributes = [];
 

--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -181,7 +181,6 @@ class DataTransferObjectTest extends TestCase
         $this->assertEquals('a', $clone->other->name);
     }
 
-    /** @test */
     public function test_optional()
     {
         $array = [
@@ -204,5 +203,13 @@ class DataTransferObjectTest extends TestCase
 
         $dto = new WithOptionalPropertyDto($array);
         $this->assertEquals($array, $dto->toArray());
+    }
+
+    public function test_required_throws_exception()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $array = [];
+
+        $dto = new BasicDto($array);
     }
 }

--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -7,6 +7,7 @@ use Spatie\DataTransferObject\Tests\Dummy\ComplexDto;
 use Spatie\DataTransferObject\Tests\Dummy\ComplexDtoWithCastedAttributeHavingCast;
 use Spatie\DataTransferObject\Tests\Dummy\ComplexDtoWithNullableProperty;
 use Spatie\DataTransferObject\Tests\Dummy\WithDefaultValueDto;
+use Spatie\DataTransferObject\Tests\Dummy\WithOptionalPropertyDto;
 
 class DataTransferObjectTest extends TestCase
 {
@@ -178,5 +179,30 @@ class DataTransferObjectTest extends TestCase
 
         $this->assertEquals('a', $clone->name);
         $this->assertEquals('a', $clone->other->name);
+    }
+
+    /** @test */
+    public function test_optional()
+    {
+        $array = [
+
+        ];
+
+        $dto = new WithOptionalPropertyDto($array);
+        $this->assertEquals($array, $dto->toArray());
+
+        $array = [
+            'name' => null,
+        ];
+
+        $dto = new WithOptionalPropertyDto($array);
+        $this->assertEquals($array, $dto->toArray());
+
+        $array = [
+            'name' => 'a',
+        ];
+
+        $dto = new WithOptionalPropertyDto($array);
+        $this->assertEquals($array, $dto->toArray());
     }
 }

--- a/tests/Dummy/WithOptionalPropertyDto.php
+++ b/tests/Dummy/WithOptionalPropertyDto.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests\Dummy;
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class WithOptionalPropertyDto extends DataTransferObject
+{
+    public ?string $name;
+}


### PR DESCRIPTION
This PR will:
- allow for optional properties to stay optional and not be automatically set with null

---

Currently, if a property is optional, it will be automatically populated with null, even though the type indicates that it shouldn't be set on object at all. Consider following DTO:
```
class WithOptionalPropertyDto extends DataTransferObject
{
    public ?string $name;
}
```

It should be possible to construct this DTO per
```
$dto = new WithOptionalPropertyDto();
```
and
```
$dto = new WithOptionalPropertyDto([
   'name' => null
]);
```
but it doesn't mean that the DTOs are equal, as first one wasn't assigned a value and second one was. Currently, in both cases value is assigned and doing `$dto->toArray()` results in `['name' => null]`