### PR TITLE
Add custom arguments to the CastWith attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,66 @@ class FooCollectionCaster implements Caster
 }
 ```
 
+### Using custom caster arguments
+
+It is also possible to pass custom arguments for your caster, one may use
+this feature to create a generic collection caster:
+
+```php
+class Bar extends DataTransferObject
+{
+    /** @var \Spatie\DataTransferObject\Tests\Foo[] */
+    #[CastWith(GenericArrayCaster::class, targetClass: Foo::class)]
+    public array $collectionOfFoo;
+
+    /** @var \Spatie\DataTransferObject\Tests\Baz[] */
+    #[CastWith(GenericArrayCaster::class, targetClass: Baz::class)]
+    public array $collectionOfBaz;
+}
+```
+
+```php
+class Foo extends DataTransferObject
+{
+    public string $name;
+}
+
+class Baz extends DataTransferObject
+{
+    public string $name;
+}
+```
+
+```php
+class GenericArrayCaster implements Caster
+{
+    public function __construct(
+        private string $type,
+        private array $args
+    ) {
+    }
+
+    public function cast(mixed $value): array
+    {
+        if ($this->type !== 'array') {
+            throw new Exception("Can only cast arrays");
+        }
+
+        if (! isset($this->args['targetClass'])) {
+            throw new Exception("targetClass argument is required");
+        }
+
+        return array_map(
+            fn (array $data) => new $this->args['targetClass'](...$data),
+            $value
+        );
+    }
+}
+```
+
+The first argument passed to the caster constructor is the type of the value being
+casted. The second is an array with all the arguments given to the `CastWith` attribute.
+
 ## Testing
 
 ``` bash

--- a/src/Attributes/CastWith.php
+++ b/src/Attributes/CastWith.php
@@ -9,11 +9,16 @@ use Spatie\DataTransferObject\Exceptions\InvalidCasterClass;
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
 class CastWith
 {
+    public array $args;
+
     public function __construct(
-        public string $casterClass
+        public string $casterClass,
+        mixed ...$args
     ) {
         if (! class_implements($this->casterClass, Caster::class)) {
             throw new InvalidCasterClass($this->casterClass);
         }
+
+        $this->args = $args;
     }
 }

--- a/src/Reflection/DataTransferObjectProperty.php
+++ b/src/Reflection/DataTransferObjectProperty.php
@@ -83,7 +83,8 @@ class DataTransferObjectProperty
         $attribute = $attributes[0]->newInstance();
 
         return new $attribute->casterClass(
-            $this->reflectionProperty->getType()?->getName()
+            $this->reflectionProperty->getType()?->getName(),
+            $attribute->args
         );
     }
 

--- a/tests/CustomCasterArgumentsTest.php
+++ b/tests/CustomCasterArgumentsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests;
+
+use Exception;
+use Spatie\DataTransferObject\Attributes\CastWith;
+use Spatie\DataTransferObject\Caster;
+use Spatie\DataTransferObject\DataTransferObject;
+
+class CustomCasterArgumentsTest extends TestCase
+{
+    /** @test */
+    public function test_generic_collection_caster()
+    {
+        $bar = new Bar(
+            [
+                'collectionOfFoo' => [
+                    ['name' => 'a'],
+                    ['name' => 'b'],
+                    ['name' => 'c'],
+                ],
+                'collectionOfBaz' => [
+                    ['name' => 'a'],
+                    ['name' => 'b'],
+                    ['name' => 'c'],
+                ],
+            ]
+        );
+
+        $this->assertCount(3, $bar->collectionOfFoo);
+        $this->assertInstanceOf(Foo::class, $bar->collectionOfFoo[0]);
+
+        $this->assertInstanceOf(Baz::class, $bar->collectionOfBaz[0]);
+        $this->assertCount(3, $bar->collectionOfBaz);
+    }
+}
+
+class Bar extends DataTransferObject
+{
+    /** @var \Spatie\DataTransferObject\Tests\Foo[] */
+    #[CastWith(GenericArrayCaster::class, targetClass: Foo::class)]
+    public array $collectionOfFoo;
+
+    /** @var \Spatie\DataTransferObject\Tests\Baz[] */
+    #[CastWith(GenericArrayCaster::class, targetClass: Baz::class)]
+    public array $collectionOfBaz;
+}
+
+class Foo extends DataTransferObject
+{
+    public string $name;
+}
+
+class Baz extends DataTransferObject
+{
+    public string $name;
+}
+
+class GenericArrayCaster implements Caster
+{
+    public function __construct(
+        private string $type,
+        private array $args
+    ) {
+    }
+
+    public function cast(mixed $value): array
+    {
+        if ($this->type !== 'array') {
+            throw new Exception("Can only cast arrays");
+        }
+
+        if (! isset($this->args['targetClass'])) {
+            throw new Exception("targetClass argument is required");
+        }
+
+        return array_map(
+            fn (array $data) => new $this->args['targetClass'](...$data),
+            $value
+        );
+    }
+}


### PR DESCRIPTION
Custom arguments can be used to provide metadata and extra context for
the user-defined casters.

This can be used, for example, to create generic array casters.

Fixes #193