### PR TITLE
Adds ArrayAccess casting to the ArrayCaster.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `data-transfer-object` will be documented in this file
 
+## Unreleased
+
+- Add casting of objects that implement `ArrayAccess` to the `ArrayCaster`.
+
 ## 3.2.0 - 2021-04-30 
 
 - Support generic casters (#199)


### PR DESCRIPTION
This PR adds the ability to cast objects that implement `ArrayAccess` to the `ArrayCaster`, it also adds the appropriate testing to ensure this works.

It should also be noted, I narrowed down the exception type to `LogicException` as opposed to `Exception` when casting an object other than an array or `ArrayAccess` is attempted.