### PR TITLE
Promoted dataTransferObject and validationErrors

### DIFF
--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -7,7 +7,7 @@ use Spatie\DataTransferObject\DataTransferObject;
 
 class ValidationException extends Exception
 {
-    public function __construct(DataTransferObject $dataTransferObject, array $validationErrors)
+    public function __construct(public DataTransferObject $dataTransferObject, public array $validationErrors)
     {
         $className = $dataTransferObject::class;
 


### PR DESCRIPTION
Hello! Just started using the library, and we're really enjoying it.

One use case that isn't easily supported (as far as I can see) is being able to access the results of a ValidationException – at present they are concatenated into a string.

This doesn't really work for our use case as we need to access individual messages and perform post-processing on the exceptions.

There's a number of ways that this could be done, but I thought the least invasive would be making the validationErrors available as a property (dataTransferObject has been promoted more for completeness).

