### PR TITLE
Update ArrayCaster to accept objects (of the correct class) alongside arrays that get cast like normal

### DIFF
--- a/src/Casters/ArrayCaster.php
+++ b/src/Casters/ArrayCaster.php
@@ -27,23 +27,34 @@ class ArrayCaster implements Caster
         throw new LogicException("Caster [ArrayCaster] may only be used to cast arrays or objects that implement ArrayAccess.");
     }
 
-    private function castArray(mixed $value): array
+    private function castArray(array $value): array
     {
-        return array_map(
-            fn (array $data) => new $this->itemType(...$data),
-            $value
-        );
+        return array_map([$this, 'makeItem'], $value);
     }
 
-    private function castArrayAccess(mixed $value): ArrayAccess
+    private function castArrayAccess(array $value): ArrayAccess
     {
         $arrayAccess = new $this->type();
 
-        array_walk(
-            $value,
-            fn (array $data) => $arrayAccess[] = new $this->itemType(...$data)
-        );
+        foreach ($this->castArray($value) as $item) {
+            $arrayAccess[] = $item;
+        }
 
         return $arrayAccess;
+    }
+
+    private function makeItem(mixed $data): mixed
+    {
+        if ($data instanceof $this->itemType) {
+            return $data;
+        }
+
+        if (is_array($data)) {
+            return new $this->itemType(...$data);
+        }
+
+        throw new LogicException(
+            'Caster [ArrayCaster] requires each item to be either an array or an instance of the specified class.'
+        );
     }
 }

--- a/tests/CustomCasterArgumentsTest.php
+++ b/tests/CustomCasterArgumentsTest.php
@@ -17,12 +17,12 @@ class CustomCasterArgumentsTest extends TestCase
             [
                 'collectionOfFoo' => [
                     ['name' => 'a'],
-                    ['name' => 'b'],
+                    new Foo(name: 'b'),
                     ['name' => 'c'],
                 ],
                 'collectionOfBaz' => [
                     ['name' => 'a'],
-                    ['name' => 'b'],
+                    new Baz(name: 'b'),
                     ['name' => 'c'],
                 ],
             ]
@@ -43,12 +43,12 @@ class CustomCasterArgumentsTest extends TestCase
             [
                 'collectionOfFoo' => [
                     ['name' => 'a'],
-                    ['name' => 'b'],
+                    new Foo(name: 'b'),
                     ['name' => 'c'],
                 ],
                 'collectionOfBaz' => [
                     ['name' => 'a'],
-                    ['name' => 'b'],
+                    new Baz(name: 'b'),
                     ['name' => 'c'],
                 ],
             ]


### PR DESCRIPTION
Hi Brendt and co.  Thanks for your work on this useful project.

I came across a situation that would be helpful to me if it were altered slightly.  I hope it's something that's helpful for others too…

---

Usually,  I build DTO objects by passing the desired child DTO objects.  But sometimes I need these _same_ DTOs to be hydrated from serialised arrays.

When using the **ArrayCaster** to cast arrays into objects,  the elements to be cast _must_ be arrays (otherwise an error is generated).

This PR lets you also pass in objects of the desired type (no cast needed),  as well as the original behaviour (which casts the array).  This way, both situations are covered.

``` php
class Bar extends DataTransferObject
{
    /** @var Foo[] */
    public array $collectionOfFoo;
}

class Baz extends DataTransferObject
{
    /** @var Foo[] */
    #[CastWith(ArrayCaster::class, itemType: Foo::class)]
    public array $collectionOfFoo;
}

class Foo extends DataTransferObject
{
    public string $name;
}
```

``` php
// normal usage without casting
$bar = new Bar(
    collectionOfFoo: [
        new Foo(name: 'a'),
        new Foo(name: 'b'),
        new Foo(name: 'c'),
    ],
);

// normal usage when casting
$bar = new Baz([
    'collectionOfFoo' => [
        ['name' => 'a'],
        ['name' => 'b'],
        ['name' => 'c'],
    ],
]);

// passing objects when Baz is expecting arrays to cast - would normally generate an error
$bar = new Baz(
    collectionOfFoo: [
        new Foo(name: 'a'),
        new Foo(name: 'b'),
        new Foo(name: 'c'),
    ],
);

// a combination of arrays and objects - would normally generate an error
$bar = new Baz([
    'collectionOfFoo' => [
        ['name' => 'a'],
        new Foo(name: 'b'),
        ['name' => 'c'],
    ],
]);
```

I split the PR up into two commits;  The first containing updated tests to show the error,  and the second with the updated code. I can squash them if desired.