### PR TITLE
Feat(StrictTypes) Now works with strict types

### DIFF
--- a/src/Arr.php
+++ b/src/Arr.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject;
 

--- a/src/Attributes/CastWith.php
+++ b/src/Attributes/CastWith.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Attributes;
 

--- a/src/Attributes/DefaultCast.php
+++ b/src/Attributes/DefaultCast.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Attributes;
 

--- a/src/Attributes/StrictType.php
+++ b/src/Attributes/StrictType.php
@@ -6,6 +6,6 @@ namespace Spatie\DataTransferObject\Attributes;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_CLASS)]
-class Strict
+class StrictType
 {
 }

--- a/src/Caster.php
+++ b/src/Caster.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject;
 

--- a/src/Casters/ArrayCaster.php
+++ b/src/Casters/ArrayCaster.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Casters;
 

--- a/src/Casters/DataTransferObjectCaster.php
+++ b/src/Casters/DataTransferObjectCaster.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Casters;
 

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject;
 
@@ -24,8 +25,10 @@ abstract class DataTransferObject
 
         $class = new DataTransferObjectClass($this);
 
+        $isStricType = $class->isStrictType();
+
         foreach ($class->getProperties() as $property) {
-            $property->setValue($args[$property->name] ?? $this->{$property->name} ?? null);
+            $property->setValue($args[$property->name] ?? $this->{$property->name} ?? null, $property->name, $isStricType);
 
             unset($args[$property->name]);
         }

--- a/src/Exceptions/InvalidCasterClass.php
+++ b/src/Exceptions/InvalidCasterClass.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Exceptions;
 

--- a/src/Exceptions/UnknownProperties.php
+++ b/src/Exceptions/UnknownProperties.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Exceptions;
 

--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Exceptions;
 

--- a/src/Reflection/DataTransferObjectClass.php
+++ b/src/Reflection/DataTransferObjectClass.php
@@ -1,10 +1,12 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Reflection;
 
 use ReflectionClass;
 use ReflectionProperty;
 use Spatie\DataTransferObject\Attributes\Strict;
+use Spatie\DataTransferObject\Attributes\StrictType;
 use Spatie\DataTransferObject\DataTransferObject;
 use Spatie\DataTransferObject\Exceptions\ValidationException;
 
@@ -15,6 +17,8 @@ class DataTransferObjectClass
     private DataTransferObject $dataTransferObject;
 
     private bool $isStrict;
+
+    private bool $isStrictType;
 
     public function __construct(DataTransferObject $dataTransferObject)
     {
@@ -67,5 +71,10 @@ class DataTransferObjectClass
     public function isStrict(): bool
     {
         return $this->isStrict ??= ! empty($this->reflectionClass->getAttributes(Strict::class));
+    }
+
+    public function isStrictType(): bool
+    {
+        return $this->isStrictType ??= ! empty($this->reflectionClass->getAttributes(StrictType::class));
     }
 }

--- a/src/Reflection/DataTransferObjectProperty.php
+++ b/src/Reflection/DataTransferObjectProperty.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Reflection;
 
@@ -37,13 +38,19 @@ class DataTransferObjectProperty
         $this->caster = $this->resolveCaster();
     }
 
-    public function setValue(mixed $value): void
+    public function setValue(mixed $value, string $nameProperty, bool $isStrictType): void
     {
         if ($this->caster && $value !== null) {
             $value = $this->caster->cast($value);
         }
 
-        $this->reflectionProperty->setValue($this->dataTransferObject, $value);
+        if ($isStrictType) {
+            $this->dataTransferObject->{$nameProperty} = $value;
+        }
+
+        if (!$isStrictType) {
+            $this->reflectionProperty->setValue($this->dataTransferObject, $value);
+        }
     }
 
     /**

--- a/src/Validation/ValidationResult.php
+++ b/src/Validation/ValidationResult.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Validation;
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject;
 

--- a/tests/ArrayCaster/ArrayCasterTest.php
+++ b/tests/ArrayCaster/ArrayCasterTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests\ArrayCaster;
 

--- a/tests/CasterOnObjectTest.php
+++ b/tests/CasterOnObjectTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests;
 

--- a/tests/CasterOnPropertyTest.php
+++ b/tests/CasterOnPropertyTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests;
 

--- a/tests/CasterWithDataTransferObjectsTest.php
+++ b/tests/CasterWithDataTransferObjectsTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests;
 

--- a/tests/CollectionCaster/CollectionCasterTest.php
+++ b/tests/CollectionCaster/CollectionCasterTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests\CollectionCaster;
 

--- a/tests/CustomCasterArgumentsTest.php
+++ b/tests/CustomCasterArgumentsTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests;
 

--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests;
 

--- a/tests/DefaultCasterTest.php
+++ b/tests/DefaultCasterTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests;
 

--- a/tests/Dummy/BasicArrayDto.php
+++ b/tests/Dummy/BasicArrayDto.php
@@ -5,9 +5,7 @@ namespace Spatie\DataTransferObject\Tests\Dummy;
 
 use Spatie\DataTransferObject\DataTransferObject;
 
-class ComplexDto extends DataTransferObject
+class BasicArrayDto extends DataTransferObject
 {
-    public string $name;
-
-    public BasicDto $other;
+    public array $field;
 }

--- a/tests/Dummy/BasicArrayStrictTypeDto.php
+++ b/tests/Dummy/BasicArrayStrictTypeDto.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests\Dummy;
+
+use Spatie\DataTransferObject\Attributes\StrictType;
+use Spatie\DataTransferObject\DataTransferObject;
+
+#[StrictType]
+class BasicArrayStrictTypeDto extends DataTransferObject
+{
+    public array $field;
+}

--- a/tests/Dummy/BasicBooleanDto.php
+++ b/tests/Dummy/BasicBooleanDto.php
@@ -5,9 +5,7 @@ namespace Spatie\DataTransferObject\Tests\Dummy;
 
 use Spatie\DataTransferObject\DataTransferObject;
 
-class ComplexDto extends DataTransferObject
+class BasicBooleanDto extends DataTransferObject
 {
-    public string $name;
-
-    public BasicDto $other;
+    public bool $field;
 }

--- a/tests/Dummy/BasicBooleanStrictTypeDto.php
+++ b/tests/Dummy/BasicBooleanStrictTypeDto.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests\Dummy;
+
+use Spatie\DataTransferObject\Attributes\StrictType;
+use Spatie\DataTransferObject\DataTransferObject;
+
+#[StrictType]
+class BasicBooleanStrictTypeDto extends DataTransferObject
+{
+    public bool $field;
+}

--- a/tests/Dummy/BasicDto.php
+++ b/tests/Dummy/BasicDto.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests\Dummy;
 

--- a/tests/Dummy/BasicFloatDto.php
+++ b/tests/Dummy/BasicFloatDto.php
@@ -5,9 +5,7 @@ namespace Spatie\DataTransferObject\Tests\Dummy;
 
 use Spatie\DataTransferObject\DataTransferObject;
 
-class ComplexDto extends DataTransferObject
+class BasicFloatDto extends DataTransferObject
 {
-    public string $name;
-
-    public BasicDto $other;
+    public float $field;
 }

--- a/tests/Dummy/BasicFloatStrictTypeDto.php
+++ b/tests/Dummy/BasicFloatStrictTypeDto.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests\Dummy;
+
+use Spatie\DataTransferObject\Attributes\StrictType;
+use Spatie\DataTransferObject\DataTransferObject;
+
+#[StrictType]
+class BasicFloatStrictTypeDto extends DataTransferObject
+{
+    public float $field;
+}

--- a/tests/Dummy/BasicIntegerDto.php
+++ b/tests/Dummy/BasicIntegerDto.php
@@ -5,9 +5,7 @@ namespace Spatie\DataTransferObject\Tests\Dummy;
 
 use Spatie\DataTransferObject\DataTransferObject;
 
-class ComplexDto extends DataTransferObject
+class BasicIntegerDto extends DataTransferObject
 {
-    public string $name;
-
-    public BasicDto $other;
+    public int $field;
 }

--- a/tests/Dummy/BasicIntegerStrictTypeDto.php
+++ b/tests/Dummy/BasicIntegerStrictTypeDto.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests\Dummy;
+
+use Spatie\DataTransferObject\Attributes\StrictType;
+use Spatie\DataTransferObject\DataTransferObject;
+
+#[StrictType]
+class BasicIntegerStrictTypeDto extends DataTransferObject
+{
+    public int $field;
+}

--- a/tests/Dummy/BasicStringDto.php
+++ b/tests/Dummy/BasicStringDto.php
@@ -5,9 +5,7 @@ namespace Spatie\DataTransferObject\Tests\Dummy;
 
 use Spatie\DataTransferObject\DataTransferObject;
 
-class ComplexDto extends DataTransferObject
+class BasicStringDto extends DataTransferObject
 {
-    public string $name;
-
-    public BasicDto $other;
+    public string $field;
 }

--- a/tests/Dummy/BasicStringStrictTypeDto.php
+++ b/tests/Dummy/BasicStringStrictTypeDto.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests\Dummy;
+
+use Spatie\DataTransferObject\Attributes\StrictType;
+use Spatie\DataTransferObject\DataTransferObject;
+
+#[StrictType]
+class BasicStringStrictTypeDto extends DataTransferObject
+{
+    public string $field;
+}

--- a/tests/Dummy/ComplexDtoWithCast.php
+++ b/tests/Dummy/ComplexDtoWithCast.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests\Dummy;
 

--- a/tests/Dummy/ComplexDtoWithCastedAttributeHavingCast.php
+++ b/tests/Dummy/ComplexDtoWithCastedAttributeHavingCast.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests\Dummy;
 

--- a/tests/Dummy/ComplexDtoWithNullableProperty.php
+++ b/tests/Dummy/ComplexDtoWithNullableProperty.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests\Dummy;
 

--- a/tests/Dummy/ComplexObject.php
+++ b/tests/Dummy/ComplexObject.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests\Dummy;
 

--- a/tests/Dummy/ComplexObjectCaster.php
+++ b/tests/Dummy/ComplexObjectCaster.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests\Dummy;
 

--- a/tests/Dummy/ComplexObjectWithCaster.php
+++ b/tests/Dummy/ComplexObjectWithCaster.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests\Dummy;
 

--- a/tests/Dummy/ComplexObjectWithCasterCaster.php
+++ b/tests/Dummy/ComplexObjectWithCasterCaster.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests\Dummy;
 

--- a/tests/Dummy/ComplexStrictTypeDto.php
+++ b/tests/Dummy/ComplexStrictTypeDto.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests\Dummy;
+
+use Spatie\DataTransferObject\Attributes\StrictType;
+use Spatie\DataTransferObject\DataTransferObject;
+
+#[StrictType]
+class ComplexStrictTypeDto extends DataTransferObject
+{
+    public BasicBooleanStrictTypeDto $field;
+}

--- a/tests/Dummy/NumberBetween.php
+++ b/tests/Dummy/NumberBetween.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests\Dummy;
 

--- a/tests/Dummy/WithDefaultValueDto.php
+++ b/tests/Dummy/WithDefaultValueDto.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests\Dummy;
 

--- a/tests/Reflection/DataTransferObjectClassTest.php
+++ b/tests/Reflection/DataTransferObjectClassTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests\Reflection;
 

--- a/tests/ScalarPropertyTest.php
+++ b/tests/ScalarPropertyTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests;
 

--- a/tests/StrictDtoTest.php
+++ b/tests/StrictDtoTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests;
 

--- a/tests/StrictTypesTest.php
+++ b/tests/StrictTypesTest.php
@@ -1,0 +1,173 @@
+<?php
+declare(strict_types=1);
+
+namespace Spatie\DataTransferObject\Tests;
+
+use Spatie\DataTransferObject\Tests\Dummy\BasicArrayStrictTypeDto;
+use Spatie\DataTransferObject\Tests\Dummy\BasicBooleanDto;
+use Spatie\DataTransferObject\Tests\Dummy\BasicBooleanStrictTypeDto;
+use Spatie\DataTransferObject\Tests\Dummy\BasicFloatDto;
+use Spatie\DataTransferObject\Tests\Dummy\BasicFloatStrictTypeDto;
+use Spatie\DataTransferObject\Tests\Dummy\BasicIntegerDto;
+use Spatie\DataTransferObject\Tests\Dummy\BasicIntegerStrictTypeDto;
+use Spatie\DataTransferObject\Tests\Dummy\BasicStringDto;
+use Spatie\DataTransferObject\Tests\Dummy\BasicStringStrictTypeDto;
+use Spatie\DataTransferObject\Tests\Dummy\ComplexStrictTypeDto;
+use TypeError;
+
+class StrictTypesTest extends TestCase
+{
+    /** @test */
+    public function boolPropertyTypeStrictFailsTest()
+    {
+        $this->expectException(TypeError::class);
+        $dto = new BasicBooleanStrictTypeDto(
+            field : 2
+        );
+    }
+
+    /** @test */
+    public function boolPropertyTypeStrictSuccessTest()
+    {
+        $dto = new BasicBooleanStrictTypeDto(
+            field : false
+        );
+
+        $this->assertEquals($dto->toArray(), ['field' => false]);
+    }
+
+    /** @test */
+    public function complexBoolPropertyTypeStrictFailsTest()
+    {
+        $this->expectException(TypeError::class);
+        $dto = new ComplexStrictTypeDto(
+            field: ['field' => 2]
+        );
+    }
+
+    /** @test */
+    public function complexBoolPropertyTypeStrictSuccessTest()
+    {
+        $dto = new ComplexStrictTypeDto(
+            field: ['field' => true]
+        );
+
+        $this->assertEquals($dto->toArray(), ['field' => ['field' => true]]);
+    }
+
+    /** @test */
+    public function integerPropertyTypeStrictFailsTest()
+    {
+        $this->expectException(TypeError::class);
+        $dto = new BasicIntegerStrictTypeDto(
+            field : "2"
+        );
+    }
+
+    /** @test */
+    public function integerPropertyTypeStrictSuccessTest()
+    {
+        $dto = new BasicIntegerStrictTypeDto(
+            field : 33
+        );
+        
+        $this->assertEquals($dto->toArray(), ['field' => 33]);
+    }
+
+    /** @test */
+    public function arrayPropertyTypeStrictFailsTest()
+    {
+        $this->expectException(TypeError::class);
+        $dto = new BasicArrayStrictTypeDto(
+            field : "text"
+        );
+    }
+
+    /** @test */
+    public function arrayPropertyTypeStrictSuccessTest()
+    {
+        $dto = new BasicArrayStrictTypeDto(
+            field : [55]
+        );
+        
+        $this->assertEquals($dto->toArray(), ['field' => [55]]);
+    }
+
+    /** @test */
+    public function floatPropertyTypeStrictFailsTest()
+    {
+        $this->expectException(TypeError::class);
+        $dto = new BasicFloatStrictTypeDto(
+            field : "3"
+        );
+    }
+
+    /** @test */
+    public function floatPropertyTypeStrictSuccessTest()
+    {
+        $dto = new BasicFloatStrictTypeDto(
+            field : 2.0
+        );
+
+        $this->assertEquals($dto->toArray(), ['field' => 2.0]);
+    }
+
+    /** @test */
+    public function stringPropertyTypeStrictFailsTest()
+    {
+        $this->expectException(TypeError::class);
+        $dto = new BasicStringStrictTypeDto(
+            field : true
+        );
+    }
+
+    /** @test */
+    public function stringPropertyTypeStrictSuccessTest()
+    {
+        $dto = new BasicStringStrictTypeDto(
+            field : "2.5"
+        );
+
+        $this->assertEquals($dto->toArray(), ['field' => 2.5]);
+    }
+
+    /** @test */
+    public function boolPropertySuccessTest()
+    {
+        $dto = new BasicBooleanDto(
+            field : 2
+        );
+
+        $this->assertEquals($dto->toArray(), ['field' => true]);
+    }
+
+    /** @test */
+    public function floatPropertySuccessTest()
+    {
+        $dto = new BasicFloatDto(
+            field : "2.2"
+        );
+
+        $this->assertEquals($dto->toArray(), ['field' => 2.2]);
+    }
+
+    /** @test */
+    public function integerPropertySuccessTest()
+    {
+        $dto = new BasicIntegerDto(
+            field : "66"
+        );
+
+        $this->assertEquals($dto->toArray(), ['field' => 66]);
+    }
+
+    /** @test */
+    public function stringPropertySuccessTest()
+    {
+        $dto = new BasicStringDto(
+            field : 100
+        );
+
+        $this->assertEquals($dto->toArray(), ['field' => "100"]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 declare(strict_types=1);
 

--- a/tests/UnionDtoTest.php
+++ b/tests/UnionDtoTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests;
 

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spatie\DataTransferObject\Tests;
 


### PR DESCRIPTION
Hello,

Using this library I have run into a problem when trying to use strict types.
When creating a DTO with a Boolean property, if it receives a value greater than 1, it is set to true instead of giving a type error.

```
<?php
class MyDto extends DataTransferObject {
    public bool $field;
}

$dto = new MyDto(
    field:2
);

echo $dto->field;
```
The result is "true" as boolean but should be a error type if you are using strict_types=1.
I thought this was an error and I reported it to PHP and they replied stating everything was fine and that it was not an error, more info at https://bugs.php.net/bug.php?id=81258

So I have modified the library so that it can use strict types.
Now you can assign an attribute to indicate if the DTO uses strict types, by default it does not use them.

```
<?php

#[StrictTypes]
class MyDto extends DataTransferObject {
    public bool $field;
}

$dto = new MyDto(
    field:2
);
//This will fail with TypeError Exception
```
The most important change is in Src \ Reflection \ DataTransferObjectProperty.php and the tests for strict types in Tests \ StrictTypesTest.php

Review the modification since surely there is a more elegant way to do it.

I hope to be helpful.
