### PR TITLE
Support mapped properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ class NumberBetween implements Validator
 
 ## Mapping
 
-You can map a DTO property from an source property with a different name using the `#[MapFrom()]` attribute.
+You can map a DTO property from a source property with a different name using the `#[MapFrom]` attribute.
 
 It works with a "dot" notation property name or an index.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ class MyDTO extends DataTransferObject
     #[NumberBetween(1, 100)]
     public int $a;
     
-    #[MapFrom('cityName')]
+    #[MapFrom('address.city')]
     public string $city;
 }
 ```
@@ -294,17 +294,23 @@ class NumberBetween implements Validator
 
 You can map a DTO property from an source property with a different name using the `#[MapFrom()]` attribute.
 
-It works with a property name or an index.
+It works with a "dot" notation property name or an index.
 
 ```php
 class PostDTO extends DataTransferObject
 {
     #[MapFrom('postTitle')]
     public string $title;
+    
+    #[MapFrom('user.name')]
+    public string $author;
 }
 
 $dto = new PostDTO([
     'postTitle' => 'Hello world',
+    'user' => [
+        'name' => 'John Doe'
+    ]
 ]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ class MyDTO extends DataTransferObject
     
     #[NumberBetween(1, 100)]
     public int $a;
+    
+    #[MapFrom('cityName')]
+    public string $city;
 }
 ```
 
@@ -285,6 +288,38 @@ class NumberBetween implements Validator
         return ValidationResult::valid();
     }
 }
+```
+
+## Mapping
+
+You can map a DTO property from an source property with a different name using the `#[MapFrom()]` attribute.
+
+It works with a property name or an index.
+
+```php
+class PostDTO extends DataTransferObject
+{
+    #[MapFrom('postTitle')]
+    public string $title;
+}
+
+$dto = new PostDTO([
+    'postTitle' => 'Hello world',
+]);
+```
+
+```php
+class UserDTO extends DataTransferObject
+{
+
+    #[MapFrom(0)]
+    public string $firstName;
+    
+    #[MapFrom(1)]
+    public string $lastName;
+}
+
+$dto = new UserDTO(['John', 'Doe']);
 ```
 
 ## Strict DTOs

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -50,6 +50,40 @@ class Arr
         return $array;
     }
 
+    public static function get($array, $key, $default = null)
+    {
+        if (! static::accessible($array)) {
+            return $default;
+        }
+
+        if (is_null($key)) {
+            return $array;
+        }
+
+        if (static::exists($array, $key)) {
+            return $array[$key];
+        }
+
+        if (strpos($key, '.') === false) {
+            return $array[$key] ?? $default;
+        }
+
+        foreach (explode('.', $key) as $segment) {
+            if (static::accessible($array) && static::exists($array, $segment)) {
+                $array = $array[$segment];
+            } else {
+                return $default;
+            }
+        }
+
+        return $array;
+    }
+
+    public static function accessible($value)
+    {
+        return is_array($value) || $value instanceof ArrayAccess;
+    }
+
     public static function exists($array, $key): bool
     {
         if ($array instanceof ArrayAccess) {

--- a/src/Attributes/MapFrom.php
+++ b/src/Attributes/MapFrom.php
@@ -10,7 +10,7 @@ use Spatie\DataTransferObject\Exceptions\InvalidCasterClass;
 class MapFrom
 {
     public function __construct(
-        protected string | int $attribute,
+        public string | int $name,
     ) {
     }
 }

--- a/src/Attributes/MapFrom.php
+++ b/src/Attributes/MapFrom.php
@@ -10,7 +10,7 @@ use Spatie\DataTransferObject\Exceptions\InvalidCasterClass;
 class MapFrom
 {
     public function __construct(
-        protected mixed $attribute,
+        protected string | int $attribute,
     ) {
     }
 }

--- a/src/Attributes/MapFrom.php
+++ b/src/Attributes/MapFrom.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\DataTransferObject\Attributes;
+
+use Attribute;
+use Spatie\DataTransferObject\Caster;
+use Spatie\DataTransferObject\Exceptions\InvalidCasterClass;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
+class MapFrom
+{
+    public function __construct(
+        protected mixed $attribute,
+    ) {
+    }
+}

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -25,9 +25,9 @@ abstract class DataTransferObject
         $class = new DataTransferObjectClass($this);
 
         foreach ($class->getProperties() as $property) {
-            $property->setValue($args[$property->name] ?? $this->{$property->name} ?? null);
+            $property->setValue(Arr::get($args, $property->name) ?? $this->{$property->name} ?? null);
 
-            unset($args[$property->name]);
+            Arr::forget($args, $property->name);
         }
 
         if ($class->isStrict() && count($args)) {

--- a/src/Reflection/DataTransferObjectProperty.php
+++ b/src/Reflection/DataTransferObjectProperty.php
@@ -10,6 +10,7 @@ use ReflectionProperty;
 use ReflectionUnionType;
 use Spatie\DataTransferObject\Attributes\CastWith;
 use Spatie\DataTransferObject\Attributes\DefaultCast;
+use Spatie\DataTransferObject\Attributes\MapFrom;
 use Spatie\DataTransferObject\Caster;
 use Spatie\DataTransferObject\DataTransferObject;
 use Spatie\DataTransferObject\Validator;
@@ -32,7 +33,7 @@ class DataTransferObjectProperty
         $this->dataTransferObject = $dataTransferObject;
         $this->reflectionProperty = $reflectionProperty;
 
-        $this->name = $this->reflectionProperty->name;
+        $this->name = $this->resolveMappedProperty();
 
         $this->caster = $this->resolveCaster();
     }
@@ -149,5 +150,16 @@ class DataTransferObjectProperty
         }
 
         return null;
+    }
+
+    private function resolveMappedProperty(): mixed
+    {
+        $attributes = $this->reflectionProperty->getAttributes(MapFrom::class);
+
+        if (! count($attributes)) {
+            return $this->reflectionProperty->name;
+        }
+
+        return $attributes[0]->getArguments()[0];
     }
 }

--- a/src/Reflection/DataTransferObjectProperty.php
+++ b/src/Reflection/DataTransferObjectProperty.php
@@ -160,6 +160,6 @@ class DataTransferObjectProperty
             return $this->reflectionProperty->name;
         }
 
-        return $attributes[0]->getArguments()[0];
+        return $attributes[0]->newInstance()->name;
     }
 }

--- a/src/Reflection/DataTransferObjectProperty.php
+++ b/src/Reflection/DataTransferObjectProperty.php
@@ -152,7 +152,7 @@ class DataTransferObjectProperty
         return null;
     }
 
-    private function resolveMappedProperty(): mixed
+    private function resolveMappedProperty(): string | int
     {
         $attributes = $this->reflectionProperty->getAttributes(MapFrom::class);
 

--- a/tests/MapFromTest.php
+++ b/tests/MapFromTest.php
@@ -29,4 +29,15 @@ class MapFromTest extends TestCase
 
         $this->assertEquals('Doe', $dto->lastName);
     }
+
+    /** @test */
+    public function property_is_mapped_from_dot_notation()
+    {
+        $dto = new class(['address' => ['city' => 'London']]) extends DataTransferObject {
+            #[MapFrom('address.city')]
+            public string $city;
+        };
+
+        $this->assertEquals('London', $dto->city);
+    }
 }

--- a/tests/MapFromTest.php
+++ b/tests/MapFromTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests;
+
+use Spatie\DataTransferObject\Attributes\CastWith;
+use Spatie\DataTransferObject\Attributes\MapFrom;
+use Spatie\DataTransferObject\DataTransferObject;
+
+class MapFromTest extends TestCase
+{
+    /** @test */
+    public function property_is_mapped_from_attribute_name()
+    {
+        $dto = new class(count: 42) extends DataTransferObject {
+            #[MapFrom('count')]
+            public int $originalCount;
+        };
+
+        $this->assertEquals(42, $dto->originalCount);
+    }
+
+    /** @test */
+    public function property_is_mapped_from_index()
+    {
+        $dto = new class(['John', 'Doe']) extends DataTransferObject {
+            #[MapFrom(1)]
+            public string $lastName;
+        };
+
+        $this->assertEquals('Doe', $dto->lastName);
+    }
+}


### PR DESCRIPTION
## Description

This pull request adds the ability to map DTO properties from source properties with different names.

This approach goes against the philosophy of doing a `1:1` mapping of DTOs, but it is undoubtedly helpful in the several cases that I present below.

## Use cases
### 1. Renaming a property when we have no control on the source data and/or for more clarity
```php 
class EventDTO extends DataTransferObject
{
    #[MapFrom('nbParticipants')]
    public string $participantCount;
}

$dto = new EventDTO([
    'nbParticipants' => 6,
]);
```

### 2. Mapping a nested property without using an additional DTO
```php 
class ProfileDTO extends DataTransferObject
{
    public string $name;

    #[MapFrom('address.city')]
    public string $city;
}

$dto = new ProfileDTO([
    'name' => 'John Doe',
    'address' => [
        'city' => 'London',
    ]
]);
```

### 3. Mapping properties from an indexed array
```php 
class UserDTO extends DataTransferObject
{
    #[MapFrom(0)]
    public string $firstName;

    #[MapFrom(1)]
    public string $lastName;
}

$dto = new UserDTO(['John', 'Doe']);
```

## Notes

This PR only requires the addition of a `resolveMappedProperty()` method in `DataTransferObjectProperty`.

However, handling the dot notation requires two additional array helpers (`Arr::get` and `Arr::accessible`). (_`Arr::get` has been simplified as default closure values are useless here._)

Despite the addition of these two methods, this PR is still lightweight but would significantly improve the DX for some cases without any significant constraint.

I'm open to change the name of the attribute if `MapFrom` doesn't suit you.