### PR TITLE
Fix array assignment bug with strict dto's

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -27,7 +27,7 @@ abstract class DataTransferObject
         foreach ($class->getProperties() as $property) {
             $property->setValue(Arr::get($args, $property->name) ?? $this->{$property->name} ?? null);
 
-            Arr::forget($args, $property->name);
+            $args = Arr::forget($args, $property->name);
         }
 
         if ($class->isStrict() && count($args)) {

--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -4,8 +4,10 @@ namespace Spatie\DataTransferObject\Tests;
 
 use Spatie\DataTransferObject\Tests\Dummy\BasicDto;
 use Spatie\DataTransferObject\Tests\Dummy\ComplexDto;
+use Spatie\DataTransferObject\Tests\Dummy\ComplexDtoWithCastedAttributeHavingArrayCast;
 use Spatie\DataTransferObject\Tests\Dummy\ComplexDtoWithCastedAttributeHavingCast;
 use Spatie\DataTransferObject\Tests\Dummy\ComplexDtoWithNullableProperty;
+use Spatie\DataTransferObject\Tests\Dummy\ComplexStrictDto;
 use Spatie\DataTransferObject\Tests\Dummy\WithDefaultValueDto;
 
 class DataTransferObjectTest extends TestCase
@@ -42,6 +44,34 @@ class DataTransferObjectTest extends TestCase
     public function create_with_nested_dto_already_casted()
     {
         $dto = new ComplexDto([
+            'name' => 'a',
+            'other' => new BasicDto([
+                'name' => 'b',
+            ]),
+        ]);
+
+        $this->assertEquals('a', $dto->name);
+        $this->assertEquals('b', $dto->other->name);
+    }
+
+    /** @test */
+    public function create_strict_with_nested_dto()
+    {
+        $dto = new ComplexStrictDto([
+            'name' => 'a',
+            'other' => [
+                'name' => 'b',
+            ],
+        ]);
+
+        $this->assertEquals('a', $dto->name);
+        $this->assertEquals('b', $dto->other->name);
+    }
+
+    /** @test */
+    public function create_strict_with_nested_dto_already_casted()
+    {
+        $dto = new ComplexStrictDto([
             'name' => 'a',
             'other' => new BasicDto([
                 'name' => 'b',

--- a/tests/Dummy/ComplexStrictDto.php
+++ b/tests/Dummy/ComplexStrictDto.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests\Dummy;
+
+use Spatie\DataTransferObject\Attributes\Strict;
+use Spatie\DataTransferObject\DataTransferObject;
+
+#[Strict]
+class ComplexStrictDto extends DataTransferObject
+{
+    public string $name;
+
+    public BasicDto $other;
+}


### PR DESCRIPTION
I came across an issue where the result of the custom `Spatie\DataTransferObject\Arr` helper is not used, which results in an exception with Strict DTO's. 
The custom `Spatie\DataTransferObject\Arr` helper is different from the Laravel `Arr` helper in that it returns an array instead of modifying an array passed by reference. 

This bug was introduced in 3.6.0. 

