### PR TITLE
Correct behavior of Arr::forget with dot keys

### DIFF
--- a/src/Arr.php
+++ b/src/Arr.php
@@ -32,19 +32,22 @@ class Arr
                 continue;
             }
 
-            $parts = explode('.', $key);
-
-            while (count($parts) > 1) {
-                $part = array_shift($parts);
-
-                if (isset($array[$part]) && is_array($array[$part])) {
-                    $array = &$array[$part];
-                } else {
-                    continue 2;
-                }
+            // Check if the key is using dot-notation
+            if (! str_contains($key, '.')) {
+                continue;
             }
 
-            unset($array[array_shift($parts)]);
+            // If we are dealing with dot-notation, recursively handle i
+            $parts = explode('.', $key);
+            $key = array_shift($parts);
+
+            if (static::exists($array, $key) && static::accessible($array[$key])) {
+                $array[$key] = static::forget($array[$key], implode('.', $parts));
+
+                if (count($array[$key]) === 0) {
+                    unset($array[$key]);
+                }
+            }
         }
 
         return $array;

--- a/tests/MapFromTest.php
+++ b/tests/MapFromTest.php
@@ -39,4 +39,41 @@ class MapFromTest extends TestCase
 
         $this->assertEquals('London', $dto->city);
     }
+
+    /** @test */
+    public function dto_can_have_mapped_and_regular_properties()
+    {
+        $data = [
+            'title' => 'Hello world',
+            'user' => [
+                'name' => 'John Doe',
+                'email' => 'john.doe@example.com',
+            ],
+            'date' => '2021-01-01',
+            'category' => [
+                'name' => 'News',
+            ]
+        ];
+
+        $dto = new class($data) extends DataTransferObject {
+            public string $title;
+
+            #[MapFrom('user.name')]
+            public string $username;
+
+            #[MapFrom('user.email')]
+            public string $email;
+
+            public string $date;
+
+            #[MapFrom('category.name')]
+            public string $categoryName;
+        };
+
+        $this->assertEquals('Hello world', $dto->title);
+        $this->assertEquals('John Doe', $dto->username);
+        $this->assertEquals('john.doe@example.com', $dto->email);
+        $this->assertEquals('2021-01-01', $dto->date);
+        $this->assertEquals('News', $dto->categoryName);
+    }
 }


### PR DESCRIPTION
An alternative solution to #230 without using references.

Fixes #229 

