### PR TITLE
Adding MapTo attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,28 @@ class UserDTO extends DataTransferObject
 $dto = new UserDTO(['John', 'Doe']);
 ```
 
+Sometimes you also want to map them during the transformation to Array. 
+A typical usecase would be transformation from camel case to snake case. 
+For that you can use the `#[MapFrom]` attribute.
+
+```php
+class UserDTO extends DataTransferObject
+{
+
+    #[MapFrom(0)]
+    #[MapTo('first_name')]
+    public string $firstName;
+    
+    #[MapFrom(1)]
+    #[MapTo('last_name')]
+    public string $lastName;
+}
+
+$dto = new UserDTO(['John', 'Doe']);
+$dto->toArray() // ['first_name' => 'John', 'last_name'=> 'Doe'];
+$dto->only('first_name')->toArray() // ['first_name' => 'John'];
+```
+
 ## Strict DTOs
 
 The previous version of this package added the `FlexibleDataTransferObject` class which allowed you to ignore properties that didn't exist on the DTO. This behaviour has been changed, all DTOs are flexible now by default, but you can make them strict by using the `#[Strict]` attribute:

--- a/src/Attributes/MapTo.php
+++ b/src/Attributes/MapTo.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\DataTransferObject\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
+class MapTo
+{
+    public function __construct(
+        public string | int $name,
+    ) {
+    }
+}

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -5,12 +5,13 @@ namespace Spatie\DataTransferObject;
 use ReflectionClass;
 use ReflectionProperty;
 use Spatie\DataTransferObject\Attributes\CastWith;
+use Spatie\DataTransferObject\Attributes\MapTo;
 use Spatie\DataTransferObject\Casters\DataTransferObjectCaster;
 use Spatie\DataTransferObject\Exceptions\UnknownProperties;
 use Spatie\DataTransferObject\Reflection\DataTransferObjectClass;
 
 #[CastWith(DataTransferObjectCaster::class)]
-abstract class DataTransferObject
+abstract class  DataTransferObject
 {
     protected array $exceptKeys = [];
 
@@ -40,7 +41,7 @@ abstract class DataTransferObject
     public static function arrayOf(array $arrayOfParameters): array
     {
         return array_map(
-            fn (mixed $parameters) => new static($parameters),
+            fn(mixed $parameters) => new static($parameters),
             $arrayOfParameters
         );
     }
@@ -58,7 +59,10 @@ abstract class DataTransferObject
                 continue;
             }
 
-            $data[$property->getName()] = $property->getValue($this);
+            $mapToAttribute = $property->getAttributes(MapTo::class);
+            $name = !count($mapToAttribute) ? $property->getName() : $mapToAttribute[0]->newInstance()->name;
+
+            $data[$name] = $property->getValue($this);
         }
 
         return $data;
@@ -109,7 +113,7 @@ abstract class DataTransferObject
                 continue;
             }
 
-            if (! is_array($value)) {
+            if (!is_array($value)) {
                 continue;
             }
 

--- a/tests/MapToTest.php
+++ b/tests/MapToTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests;
+
+use Spatie\DataTransferObject\Arr;
+use Spatie\DataTransferObject\Attributes\MapFrom;
+use Spatie\DataTransferObject\Attributes\MapTo;
+use Spatie\DataTransferObject\DataTransferObject;
+
+class MapToTest extends TestCase
+{
+    /** @test */
+    public function property_is_mapped_to_attribute_name()
+    {
+        $dto = new class(originalCount: 42) extends DataTransferObject {
+            #[MapTo('count')]
+            public int $originalCount;
+        };
+
+        $this->assertEquals(42, $dto->toArray()['count']);
+    }
+
+    /** @test */
+    public function dto_can_have_mapped_and_regular_properties()
+    {
+        $data = [
+            'title' => 'Hello world',
+            'username' => 'John Doe',
+            'date' => '2021-01-01',
+            'category' => [
+                'name' => 'News',
+            ],
+        ];
+
+        $dto = new class($data) extends DataTransferObject {
+            public string $title;
+
+            #[MapTo('author')]
+            public string $username;
+
+            public string $date;
+
+            #[MapFrom('category.name')]
+            public string $categoryName;
+        };
+
+        $dtoArray = $dto->toArray();
+        $this->assertEquals('Hello world', $dtoArray['title']);
+        $this->assertEquals('John Doe', $dtoArray['author']);
+        $this->assertEquals('2021-01-01', $dtoArray['date']);
+        $this->assertEquals('News', $dtoArray['categoryName']);
+    }
+
+    /** @test */
+    public function dto_can_have_mapped_from_and_to_and_regular_properties()
+    {
+        $data = [
+            'title' => 'Hello world',
+            'user' => [
+                'name' => 'John Doe',
+                'email' => 'john.doe@example.com',
+            ],
+            'date' => '2021-01-01',
+            'category' => [
+                'name' => 'News',
+            ],
+        ];
+
+        $dto = new class($data) extends DataTransferObject {
+            public string $title;
+
+            #[MapFrom('user.name')]
+            #[MapTo('author')]
+            public string $username;
+
+            #[MapFrom('user.email')]
+            public string $email;
+
+            public string $date;
+
+            #[MapFrom('category.name')]
+            public string $categoryName;
+        };
+
+        $dtoArray = $dto->toArray();
+        $this->assertEquals('Hello world', $dtoArray['title']);
+        $this->assertEquals('John Doe', $dtoArray['author']);
+        $this->assertEquals('john.doe@example.com', $dtoArray['email']);
+        $this->assertEquals('2021-01-01', $dtoArray['date']);
+        $this->assertEquals('News', $dtoArray['categoryName']);
+    }
+
+    /** @test */
+    public function mapped_property_can_be_except()
+    {
+        $dto = new class(originalCount: 42, villain: 'Johnny Lawrence') extends DataTransferObject {
+            #[MapTo('count')]
+            public int $originalCount;
+
+            #[MapTo('hero')]
+            public string $villain;
+        };
+
+        $dtoArray = $dto->except('count')->toArray();
+        $this->assertEquals('Johnny Lawrence', $dtoArray['hero']);
+        $this->assertFalse(Arr::exists($dtoArray, 'count'));
+    }
+
+    /** @test */
+    public function mapped_property_can_be_only_exported()
+    {
+        $dto = new class(originalCount: 42, villain: 'Johnny Lawrence') extends DataTransferObject {
+            #[MapTo('count')]
+            public int $originalCount;
+
+            #[MapTo('hero')]
+            public string $villain;
+        };
+
+        $dtoArray = $dto->only('hero')->toArray();
+        $this->assertEquals('Johnny Lawrence', $dtoArray['hero']);
+        $this->assertFalse(Arr::exists($dtoArray, 'count'));
+    }
+}


### PR DESCRIPTION
Analogous to the MapFrom attribute, I was in need for a MapTo attribute. My use case was that I needed to transform the properties to snake case while passing them to the frontend and thought that it might be useful to add it to the package itself. 
I tried to implement as simple as possible, if another way is preferred I'm willing to revise it.

It works as following:
```php
class UserDTO extends DataTransferObject
{

    #[MapFrom(0)]
    #[MapTo('first_name')]
    public string $firstName;
    
    #[MapFrom(1)]
    #[MapTo('last_name')]
    public string $lastName;
}

$dto = new UserDTO(['John', 'Doe']);
$dto->toArray() // ['first_name' => 'John', 'last_name'=> 'Doe'];
$dto->only('first_name')->toArray() // ['first_name' => 'John'];
```

