### PR TITLE
Cast properties with `self` or `parent` type

### DIFF
--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -6,6 +6,8 @@ use Spatie\DataTransferObject\Tests\Dummy\BasicDto;
 use Spatie\DataTransferObject\Tests\Dummy\ComplexDto;
 use Spatie\DataTransferObject\Tests\Dummy\ComplexDtoWithCastedAttributeHavingCast;
 use Spatie\DataTransferObject\Tests\Dummy\ComplexDtoWithNullableProperty;
+use Spatie\DataTransferObject\Tests\Dummy\ComplexDtoWithParent;
+use Spatie\DataTransferObject\Tests\Dummy\ComplexDtoWithSelf;
 use Spatie\DataTransferObject\Tests\Dummy\ComplexStrictDto;
 use Spatie\DataTransferObject\Tests\Dummy\WithDefaultValueDto;
 
@@ -207,5 +209,35 @@ class DataTransferObjectTest extends TestCase
 
         $this->assertEquals('a', $clone->name);
         $this->assertEquals('a', $clone->other->name);
+    }
+
+    /** @test */
+    public function create_with_nested_self()
+    {
+        $dto = new ComplexDtoWithSelf([
+            'name' => 'a',
+            'other' => [
+                'name' => 'b',
+            ],
+        ]);
+
+        $this->assertEquals('a', $dto->name);
+        $this->assertEquals('b', $dto->other->name);
+        $this->assertNull($dto->other->other);
+    }
+
+    /** @test */
+    public function create_with_nested_parent()
+    {
+        $dto = new ComplexDtoWithParent([
+            'name' => 'a',
+            'other' => [
+                'name' => 'b',
+            ],
+        ]);
+
+        $this->assertEquals('a', $dto->name);
+        $this->assertEquals('b', $dto->other->name);
+        $this->assertNull($dto->other->other);
     }
 }

--- a/tests/Dummy/ComplexDtoWithParent.php
+++ b/tests/Dummy/ComplexDtoWithParent.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests\Dummy;
+
+class ComplexDtoWithParent extends ComplexDtoWithSelf
+{
+    public string $name;
+
+    public ?parent $other;
+}

--- a/tests/Dummy/ComplexDtoWithSelf.php
+++ b/tests/Dummy/ComplexDtoWithSelf.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests\Dummy;
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class ComplexDtoWithSelf extends DataTransferObject
+{
+    public string $name;
+
+    public ?self $other;
+}


### PR DESCRIPTION
This PR fixes a bug when a type property has the `self` or `parent` keyword.

Here is a simple example with a nullable self property:
```php
class MyDTO extends DataTransferObject
{
    public string $name;
    public ?self $parent;
}

$dto = new MyDTO([
    'name' => 'a',
    'parent' => ['name' => 'b'],
]);

// TypeError: Cannot assign array to property MyDTO::$parent of type ?self
// vendor/spatie/data-transfer-object/src/Reflection/DataTransferObjectProperty.php:47
// vendor/spatie/data-transfer-object/src/DataTransferObject.php:29
```

The same applies for the `parent` keyword.

The reason is that the `DataTransferObjectProperty` cannot resolve the caster (e.g. `DataTransferObjectCaster`) for the property, because `resolveCasterFromType()` returns an empty array.
This happens because `$type->getName()` returns `self` so `class_exists('self')` is false.
In order to fix, this I'm parsing the type name and resolving the `self` and `parent` keywords to the concrete classes.
