### PR TITLE
Ensure value is an array before trying to destruct

### DIFF
--- a/src/Arr.php
+++ b/src/Arr.php
@@ -95,4 +95,13 @@ class Arr
 
         return array_key_exists($key, $array);
     }
+
+    public static function wrap($value): array
+    {
+        if (is_null($value)) {
+            return [];
+        }
+
+        return is_array($value) ? $value : [$value];
+    }
 }

--- a/src/Casters/DataTransferObjectCaster.php
+++ b/src/Casters/DataTransferObjectCaster.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\DataTransferObject\Casters;
 
+use Spatie\DataTransferObject\Arr;
 use Spatie\DataTransferObject\Caster;
 use Spatie\DataTransferObject\DataTransferObject;
 
@@ -20,6 +21,6 @@ class DataTransferObjectCaster implements Caster
             }
         }
 
-        return new $this->classNames[0](...$value);
+        return new $this->classNames[0](...Arr::wrap($value));
     }
 }


### PR DESCRIPTION
Currently the following throws an error:

```php
class Email extends DataTransferObject
{
    public string $value;
    
    public function __construct($value)
    {
        parent::__construct([ 'value' => $value ]);
    }
}
```

```php
$works = new UserDTO([
    'email' => new Email('email@example.com'),
]);

$fail = new UserDTO([
    'email' => 'email@example.com',
]);
```

```
TypeError : Only arrays and Traversables can be unpacked
```

This PR fixes it.