### PR TITLE
add support simple types for ArrayCaster.php

### DIFF
--- a/src/Casters/ArrayCaster.php
+++ b/src/Casters/ArrayCaster.php
@@ -55,6 +55,10 @@ class ArrayCaster implements Caster
 
     private function castItem(mixed $data)
     {
+        if ($this->isSimpleType($this->itemType)) {
+            return $this->castSimpleType($data);
+        }
+
         if ($data instanceof $this->itemType) {
             return $data;
         }
@@ -67,4 +71,29 @@ class ArrayCaster implements Caster
             "Caster [ArrayCaster] each item must be an array or an instance of the specified item type [{$this->itemType}]."
         );
     }
+
+    private function castSimpleType(mixed $data) {
+
+        $dataType = gettype($data);
+
+        if ($this->isSimpleType($dataType)) {
+            settype($data, $this->itemType);
+            return $data;
+        }
+
+        throw new LogicException(
+            "Caster [ArrayCaster] given data type [{$dataType}] cannot be casted to [{$this->itemType}]"
+        );
+    }
+
+    private function isSimpleType(string $type) {
+        return in_array($type, [
+            'boolean', 'bool',
+            'integer', 'int',
+            'float', 'double',
+            'string',
+            'NULL'
+        ]);
+    }
+
 }

--- a/tests/ArrayCaster/ArrayCasterSimpleTypeTest.php
+++ b/tests/ArrayCaster/ArrayCasterSimpleTypeTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests\ArrayCaster;
+
+use LogicException;
+use Spatie\DataTransferObject\Attributes\CastWith;
+use Spatie\DataTransferObject\Casters\ArrayCaster;
+use Spatie\DataTransferObject\DataTransferObject;
+use Spatie\DataTransferObject\Tests\TestCase;
+use stdClass;
+
+class ArrayCasterSimpleTypeTest extends TestCase
+{
+    public function test_simple_type_casts() {
+
+        $testData = ['2s','s3', 1, 5.9, '0.333', '.3', '0', null, false,];
+
+        $foo = new ArraySimpleTypeCastExampleObject([
+            'collectionOfInteger' => $testData,
+            'collectionOfString' => $testData,
+            'collectionOfFloat' => $testData,
+        ]);
+
+        foreach ($foo->collectionOfInteger as $integer) {
+            $this->assertEquals('integer', gettype($integer));
+        }
+        $this->assertEquals([2, 0, 1, 5, 0, 0, 0, 0, 0], $foo->collectionOfInteger);
+
+        foreach ($foo->collectionOfString as $string) {
+            $this->assertEquals('string', gettype($string));
+        }
+        $this->assertEquals(['2s', 's3', '1', '5.9', '0.333', '.3', '0', '', ''], $foo->collectionOfString);
+
+        foreach ($foo->collectionOfFloat as $float) {
+            $this->assertEquals('double', gettype($float));
+        }
+        $this->assertEquals([2, 0, 1, 5.9, 0.333, 0.3, 0, 0, 0,], $foo->collectionOfFloat);
+    }
+
+    public function test_array_is_not_simple() {
+        $this->expectException(LogicException::class);
+        $this->expectErrorMessage('cannot be casted to [int]');
+        new ArraySimpleTypeCastExampleObject([
+            'collectionOfInteger' => [
+                ['78'],
+            ],
+        ]);
+    }
+
+    public function test_object_is_not_simple() {
+        $this->expectException(LogicException::class);
+        $this->expectErrorMessage('cannot be casted to [int]');
+        new ArraySimpleTypeCastExampleObject([
+            'collectionOfInteger' => [
+                new stdClass()
+            ],
+        ]);
+    }
+}
+
+
+class ArraySimpleTypeCastExampleObject extends DataTransferObject {
+    /** @var int[] */
+    #[CastWith(ArrayCaster::class, 'int')]
+    public array $collectionOfInteger = [];
+    /** @var string[] */
+    #[CastWith(ArrayCaster::class, 'string')]
+    public array $collectionOfString = [];
+    /** @var float[] */
+    #[CastWith(ArrayCaster::class, 'float')]
+    public array $collectionOfFloat = [];
+}


### PR DESCRIPTION
problem: ArrayCaster cannot cast a simple type

```php
$data = ['1', '2'];
$foo = new Foo(['bar' => $data]);

class Foo extends DataTransferObject {
    /** @var int[] */
    #[CastWith(ArrayCaster::class, 'int')]
    public array $bar = [];
}
```
This PR adds support for simple types such as int, float, string, bool
