### PR TITLE
Feature/cast properties from method

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,22 @@ class ComplexObjectWithCast
 }
 ```
 
+### Caster methods
+
+Instead of creating a custom caster and using `CastWith`, you can create a cast method on the DTO, using the naming convention `cast<PropertyName>`.
+
+```php
+class MyDTO extends DataTransferObject
+{
+    public string $name;
+    
+    public function castName($value)
+    {
+        return strtoupper($value);
+    }
+}
+```
+
 ### Default casters
 
 It's possible to define default casters on a DTO class itself. These casters will be used whenever a property with a given type is encountered within the DTO class.

--- a/tests/CasterMethodOnObjectTest.php
+++ b/tests/CasterMethodOnObjectTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests;
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class CasterMethodOnObjectTest extends TestCase
+{
+    /** @test */
+    public function property_is_casted_with_object_method()
+    {
+        $dto = new class(['someProperty' => 'test']) extends DataTransferObject {
+            public string $someProperty;
+
+            public function castSomeProperty(mixed $value)
+            {
+                return strtoupper($value);
+            }
+        };
+
+        $this->assertEquals('TEST', $dto->someProperty);
+    }
+}


### PR DESCRIPTION
This PR proposes the addition of casting properties on a DTO without using attributes and instead specifying a castAttribute method on the DTO. This is useful for one-off casts, that would otherwise require a seperate Caster class.

Example usage:

```php
class MyDTO extends DataTransferObject
{
    public string $name;
    
    public function castName($value)
    {
        return strtoupper($value);
    }
}
```

In this example, the DTO would automatically find the castName function and use this alongside any other provided Casters.

Any input on the behaviour of using this in combination with a CastWith attribute would be greatly appreciated.

Consider the following example, where ToLowerCaster is a simple caster that casts the value to all lower case.

```php
class MyDTO extends DataTransferObject
{
    #[CastWith(ToLowerCaster::class)]
    public string $name;
    
    public function castName($value)
    {
        return strtoupper($value);
    }
}
```
What should the expected result be in such a case?

For now, it simple uses the existing logic to cast via any CastWith attribute, and then passes the casted value to the cast method, meaning the current implementation would result in name being uppercased.