### PR TITLE
Add onlyFilled method

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -86,6 +86,19 @@ abstract class DataTransferObject
         return $dataTransferObject;
     }
 
+    public function onlyFilled(): static
+    {
+        $dataTransferObject = clone $this;
+
+        foreach ($dataTransferObject->toArray() as $property => $value) {
+            if (isset($value)) {
+                $dataTransferObject->onlyKeys = [...$this->onlyKeys, $property];
+            }
+        }
+
+        return $dataTransferObject;
+    }
+
     public function clone(...$args): static
     {
         return new static(...array_merge($this->toArray(), $args));

--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -178,6 +178,19 @@ class DataTransferObjectTest extends TestCase
     }
 
     /** @test */
+    public function to_array_with_onlyFilled()
+    {
+        $array = [
+            'name' => 'Yusuf Onur SARI',
+            'other' => null,
+        ];
+
+        $dto = new ComplexDtoWithParent($array);
+
+        $this->assertEquals(['name' => 'Yusuf Onur SARI'], $dto->onlyFilled()->toArray());
+    }
+
+    /** @test */
     public function create_with_default_value()
     {
         $dto = new WithDefaultValueDto();


### PR DESCRIPTION
The onlyFilled method ensures that only filled values are returned.

For example, when we transfer the values that come with FormRequest to DTO, nullable fields come as null and may cause an update in the database.

Example:

    public function update(UserUpdateRequest $request, User $user)
    {
        $userData = (new UserData($request->validated()))->onlyFilled();

        $user = $this->userService->update($userData, $user);

        return new UserResource($user);
    }


If date_of_birth does not appear in UserUpdateRequest and this field is not mandatory in UserData, this field comes as null and the relevant field is updated as null in the table. We can avoid this problem because we get non-null fields with the onlyFilled method.