### PR TITLE
Transform DTO with DataTransformer

### DIFF
--- a/src/Attributes/TransformWith.php
+++ b/src/Attributes/TransformWith.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\DataTransferObject\Attributes;
+
+use Attribute;
+use Spatie\DataTransferObject\DataTransformer;
+use Spatie\DataTransferObject\Exceptions\InvalidDataTransformerClass;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class TransformWith
+{
+    public function __construct(public string $dataTransformerClass) {
+        if (! is_subclass_of($this->dataTransformerClass, DataTransformer::class)) {
+            throw new InvalidDataTransformerClass($this->dataTransformerClass);
+        }
+    }
+}

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -25,6 +25,19 @@ abstract class DataTransferObject
 
         $class = new DataTransferObjectClass($this);
 
+        $argsToForgetAfterTransformation = [];
+
+        foreach ($class->getDataTransformers() as $dataTransformer) {
+            $dataTransformer->transform($this, $args);
+
+            $argsToForgetAfterTransformation = [
+                ...$argsToForgetAfterTransformation,
+                ...$dataTransformer->argsToForget()
+            ];
+        }
+
+        $args = Arr::forget($args, $argsToForgetAfterTransformation);
+
         foreach ($class->getProperties() as $property) {
             $property->setValue(Arr::get($args, $property->name) ?? $this->{$property->name} ?? null);
 

--- a/src/DataTransformer.php
+++ b/src/DataTransformer.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\DataTransferObject;
+
+interface DataTransformer
+{
+    public function transform(DataTransferObject $object, ...$args): void;
+
+    /**
+     * Args that must be forgotten after transformation.
+     */
+    public function argsToForget(): array;
+}

--- a/src/Exceptions/InvalidDataTransformerClass.php
+++ b/src/Exceptions/InvalidDataTransformerClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\DataTransferObject\Exceptions;
+
+use Exception;
+use Spatie\DataTransferObject\DataTransformer;
+
+class InvalidDataTransformerClass extends Exception
+{
+    public function __construct(string $className)
+    {
+        $expected = DataTransformer::class;
+
+        parent::__construct(
+            "Class `{$className}` doesn't implement {$expected} and can't be used as a data transformer"
+        );
+    }
+}

--- a/src/Reflection/DataTransferObjectClass.php
+++ b/src/Reflection/DataTransferObjectClass.php
@@ -2,10 +2,13 @@
 
 namespace Spatie\DataTransferObject\Reflection;
 
+use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionProperty;
 use Spatie\DataTransferObject\Attributes\Strict;
+use Spatie\DataTransferObject\Attributes\TransformWith;
 use Spatie\DataTransferObject\DataTransferObject;
+use Spatie\DataTransferObject\DataTransformer;
 use Spatie\DataTransferObject\Exceptions\ValidationException;
 
 class DataTransferObjectClass
@@ -39,6 +42,22 @@ class DataTransferObjectClass
             ),
             $publicProperties
         );
+    }
+
+    /**
+     * @return iterable<DataTransformer>
+     */
+    public function getDataTransformers(): iterable
+    {
+        /** @var array<ReflectionAttribute> $reflectionAttributes */
+        $reflectionAttributes = $this->reflectionClass->getAttributes(TransformWith::class);
+
+        foreach ($reflectionAttributes as $reflectionAttribute) {
+            /** @var TransformWith $attribute */
+            $attribute = $reflectionAttribute->newInstance();
+
+            yield new $attribute->dataTransformerClass();
+        }
     }
 
     public function validate(): void

--- a/tests/DataTransformerTest.php
+++ b/tests/DataTransformerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests;
+
+use Spatie\DataTransferObject\DataTransferObject;
+use Spatie\DataTransferObject\DataTransformer;
+use Spatie\DataTransferObject\Attributes\TransformWith;
+
+class DataTransformerTest extends TestCase
+{
+    /** @test */
+    public function dto_is_transformed_with_single_data_transformer()
+    {
+        $input = ['full_name' => 'John Doe', 'result' => [3, 1, 4, 0, 0, 7]];
+        $dto = new UserResult($input);
+
+        $this->assertEquals('John', $dto->firstName);
+        $this->assertEquals('Doe', $dto->lastName);
+        $this->assertEquals(2.5, $dto->result);
+    }
+
+    /** @test */
+    public function dto_is_transformed_with_many_data_transformers()
+    {
+        $input = ['full_name' => 'John Doe', 'result' => [3, 1, 4, 0, 0, 7]];
+        $dto = new UserResultWithDetails($input);
+
+        $this->assertEquals('John', $dto->firstName);
+        $this->assertEquals('Doe', $dto->lastName);
+        $this->assertEquals(2.5, $dto->result);
+        $this->assertEquals('John Doe\'s result is 2.5 and 2 answers are incorrect.', $dto->resultInterpretation);
+    }
+}
+
+#[TransformWith(UserResultDataTransformer::class)]
+class UserResult extends DataTransferObject
+{
+    public string $firstName;
+    public string $lastName;
+    public float $result;
+}
+
+#[TransformWith(UserResultDataTransformer::class)]
+#[TransformWith(ResultInterpretationDataTransformer::class)]
+class UserResultWithDetails extends UserResult
+{
+    public string $resultInterpretation;
+}
+
+class UserResultDataTransformer implements DataTransformer
+{
+    public function transform(DataTransferObject|UserResult $object, ...$args): void
+    {
+        $fullName = explode(' ', $args[0]['full_name']);
+
+        $object->firstName = $fullName[0];
+        $object->lastName = $fullName[1];
+        $object->result = array_sum($args[0]['result']) / count($args[0]['result']);
+    }
+
+    public function argsToForget(): array
+    {
+        return ['result'];
+    }
+}
+
+class ResultInterpretationDataTransformer implements DataTransformer
+{
+    public function transform(DataTransferObject|UserResultWithDetails $object, ...$args): void
+    {
+        $object->resultInterpretation = sprintf(
+            '%s\'s result is %.1f and %d answers are incorrect.',
+            $args[0]['full_name'],
+            $object->result,
+            count(array_keys($args[0]['result'], 0))
+        );
+    }
+
+    public function argsToForget(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
I find it very helpful to transform the entire DTO during initialization and achieve ready to use DTO. `DataTransformer` can be used in `#[TransformWith]` attribute.