### PR TITLE
Added enum caster

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "illuminate/collections": "^8.36",
         "larapack/dd": "^1.1",
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^9.5.5",
         "jetbrains/phpstorm-attributes": "^1.0"
     },
     "autoload": {

--- a/src/Casters/EnumCaster.php
+++ b/src/Casters/EnumCaster.php
@@ -2,24 +2,18 @@
 
 namespace Spatie\DataTransferObject\Casters;
 
-use LogicException;
 use Spatie\DataTransferObject\Caster;
 
 class EnumCaster implements Caster
 {
     public function __construct(
         private array $types,
-        private string $enumType,
-        private string $enumValueType
+        private string $enumType
     ) {
     }
 
     public function cast(mixed $value): mixed
     {
-        if (gettype($value) !== $this->enumValueType) {
-            throw new LogicException("$this->enumType can only be casted from $this->enumValueType");
-        }
-
         return $this->enumType::from($value);
     }
 }

--- a/src/Casters/EnumCaster.php
+++ b/src/Casters/EnumCaster.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\DataTransferObject\Casters;
 
-use BackedEnum;
 use LogicException;
 use Spatie\DataTransferObject\Caster;
 
@@ -16,14 +15,14 @@ class EnumCaster implements Caster
 
     public function cast(mixed $value): mixed
     {
-        if (!is_subclass_of($this->enumType, BackedEnum::class)) {
-            throw new LogicException("$this->enumType must be backed enum!");
+        if (!is_subclass_of($this->enumType, 'BackedEnum')) {
+            throw new LogicException("Caster [EnumCaster] may only be used to cast backed enums. Received [$this->enumType].");
         }
 
         $castedValue = $this->enumType::tryFrom($value);
 
         if ($castedValue === null) {
-            throw new LogicException("Couldn't cast $this->enumType with value $value");
+            throw new LogicException("Couldn't cast enum [$this->enumType] with value [$value]");
         }
 
         return $castedValue;

--- a/src/Casters/EnumCaster.php
+++ b/src/Casters/EnumCaster.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\DataTransferObject\Casters;
 
+use BackedEnum;
+use LogicException;
 use Spatie\DataTransferObject\Caster;
 
 class EnumCaster implements Caster
@@ -14,6 +16,16 @@ class EnumCaster implements Caster
 
     public function cast(mixed $value): mixed
     {
-        return $this->enumType::from($value);
+        if (!is_subclass_of($this->enumType, BackedEnum::class)) {
+            throw new LogicException("$this->enumType must be backed enum!");
+        }
+
+        $castedValue = $this->enumType::tryFrom($value);
+
+        if ($castedValue === null) {
+            throw new LogicException("Couldn't cast $this->enumType with value $value");
+        }
+
+        return $castedValue;
     }
 }

--- a/src/Casters/EnumCaster.php
+++ b/src/Casters/EnumCaster.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\DataTransferObject\Casters;
+
+use LogicException;
+use Spatie\DataTransferObject\Caster;
+
+class EnumCaster implements Caster
+{
+    public function __construct(
+        private array $types,
+        private string $enumType,
+        private string $enumValueType
+    ) {
+    }
+
+    public function cast(mixed $value): mixed
+    {
+        if (gettype($value) !== $this->enumValueType) {
+            throw new LogicException("$this->enumType can only be casted from $this->enumValueType");
+        }
+
+        return $this->enumType::from($value);
+    }
+}

--- a/tests/Casters/ArrayCasterTest.php
+++ b/tests/Casters/ArrayCasterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\DataTransferObject\Tests\ArrayCaster;
+namespace Spatie\DataTransferObject\Tests\Casters;
 
 use Exception;
 use Spatie\DataTransferObject\Attributes\CastWith;

--- a/tests/Casters/EnumCasterTest.php
+++ b/tests/Casters/EnumCasterTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests\Casters;
+
+use LogicException;
+use Spatie\DataTransferObject\Attributes\CastWith;
+use Spatie\DataTransferObject\Casters\EnumCaster;
+use Spatie\DataTransferObject\DataTransferObject;
+use Spatie\DataTransferObject\Tests\Stubs\IntegerEnum;
+use Spatie\DataTransferObject\Tests\Stubs\SimpleEnum;
+use Spatie\DataTransferObject\Tests\Stubs\StringEnum;
+use Spatie\DataTransferObject\Tests\TestCase;
+
+/** @requires PHP >= 8.1 */
+class EnumCasterTest extends TestCase
+{
+    /** @test */
+    public function test_it_cannot_cast_enum_with_wrong_value_type_given(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            'Couldn\'t cast ' . StringEnum::class .' with value 5'
+        );
+
+        new EnumCastedDataTransferObject([
+            'stringEnum' => 5
+        ]);
+    }
+
+    /** @test */
+    public function test_it_can_cast_enums(): void
+    {
+        $dto = new EnumCastedDataTransferObject([
+            'integerEnum' => 1,
+            'stringEnum' => 'test'
+        ]);
+
+        $this->assertEquals(StringEnum::Test, $dto->stringEnum);
+        $this->assertEquals(IntegerEnum::Test, $dto->integerEnum);
+    }
+
+    /** @test */
+    public function test_it_cannot_cast_simple_enums(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            SimpleEnum::class . ' must be backed enum!'
+        );
+
+        new EnumCastedDataTransferObject([
+            'simpleEnum' => 5
+        ]);
+    }
+}
+
+class EnumCastedDataTransferObject extends DataTransferObject
+{
+    #[CastWith(EnumCaster::class, StringEnum::class)]
+    public ?StringEnum $stringEnum;
+
+    #[CastWith(EnumCaster::class, IntegerEnum::class)]
+    public ?IntegerEnum $integerEnum;
+
+    #[CastWith(EnumCaster::class, SimpleEnum::class)]
+    public ?SimpleEnum $simpleEnum;
+}

--- a/tests/Casters/EnumCasterTest.php
+++ b/tests/Casters/EnumCasterTest.php
@@ -17,13 +17,15 @@ class EnumCasterTest extends TestCase
     /** @test */
     public function test_it_cannot_cast_enum_with_wrong_value_type_given(): void
     {
+        $wrongValue = 5;
+
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage(
-            'Couldn\'t cast ' . StringEnum::class .' with value 5'
+            'Couldn\'t cast enum [' . StringEnum::class . '] with value [' . $wrongValue . ']'
         );
 
         new EnumCastedDataTransferObject([
-            'stringEnum' => 5
+            'stringEnum' => $wrongValue
         ]);
     }
 
@@ -44,7 +46,7 @@ class EnumCasterTest extends TestCase
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage(
-            SimpleEnum::class . ' must be backed enum!'
+            'Caster [EnumCaster] may only be used to cast backed enums. Received [' . SimpleEnum::class . '].'
         );
 
         new EnumCastedDataTransferObject([

--- a/tests/Stubs/IntegerEnum.php
+++ b/tests/Stubs/IntegerEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests\Stubs;
+
+enum IntegerEnum: int
+{
+    case Test = 1;
+    case Test2 = 2;
+}

--- a/tests/Stubs/SimpleEnum.php
+++ b/tests/Stubs/SimpleEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests\Stubs;
+
+enum SimpleEnum
+{
+    case Test;
+    case Test2;
+}

--- a/tests/Stubs/StringEnum.php
+++ b/tests/Stubs/StringEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests\Stubs;
+
+enum StringEnum: string
+{
+    case Test = "test";
+    case Test2 = "test2";
+}


### PR DESCRIPTION
Hi there!
Me and my team often use enum caster, in our DTOs and it would be gr8 to have it by default in package
The only problem that I faced - I can't cover this caster with tests inside the package, cuz package supports PHP 8.0, and enums comes since 8.1

Here is usage example:

![image](https://user-images.githubusercontent.com/33313896/169754631-3fba0e19-3077-4fc5-9310-c8032f4b007f.png)

P.S. I will also add this information in readme, if you accept this PR
