### PR TITLE
Ability to get only filled fields from DTO

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -17,11 +17,15 @@ abstract class DataTransferObject
 
     protected array $onlyKeys = [];
 
+    protected array $args = [];
+
     public function __construct(...$args)
     {
         if (is_array($args[0] ?? null)) {
             $args = $args[0];
         }
+
+        $this->args = $args;
 
         $class = new DataTransferObjectClass($this);
 
@@ -91,17 +95,24 @@ abstract class DataTransferObject
         return new static(...array_merge($this->toArray(), $args));
     }
 
+    public function filledOnly(): static
+    {
+        return $this->only(...array_keys($this->args));
+    }
+
     public function toArray(): array
     {
+        $array = $this->all();
+
         if (count($this->onlyKeys)) {
-            $array = Arr::only($this->all(), $this->onlyKeys);
-        } else {
-            $array = Arr::except($this->all(), $this->exceptKeys);
+            $array = Arr::only($array, $this->onlyKeys);
         }
 
-        $array = $this->parseArray($array);
+        if (count($this->exceptKeys)) {
+            $array = Arr::except($array, $this->exceptKeys);
+        }
 
-        return $array;
+        return $this->parseArray($array);
     }
 
     protected function parseArray(array $array): array

--- a/tests/DataTransferObjectTest.php
+++ b/tests/DataTransferObjectTest.php
@@ -163,6 +163,38 @@ class DataTransferObjectTest extends TestCase
     }
 
     /** @test */
+    public function to_array_with_only_filled()
+    {
+        $array = [
+            'name' => 'a',
+        ];
+
+        $array2 = [
+            'name' => 'a',
+            'other' => null,
+        ];
+
+        $dto = new ComplexDtoWithNullableProperty($array);
+        $dto2 = new ComplexDtoWithNullableProperty($array2);
+
+        $this->assertEquals($array, $dto->filledOnly()->toArray());
+        $this->assertEquals($array2, $dto2->filledOnly()->toArray());
+    }
+
+    /** @test */
+    public function to_array_with_only_filled_and_except()
+    {
+        $array = [
+            'name' => 'a',
+            'other' => null,
+        ];
+
+        $dto = new ComplexDtoWithNullableProperty($array);
+
+        $this->assertEquals(['name' => 'a'], $dto->filledOnly()->except('other')->toArray());
+    }
+
+    /** @test */
     public function to_array_with_except()
     {
         $array = [


### PR DESCRIPTION
Hi again :) 

Sometimes we need to get only those values that we set when we create DTO (for example: if we need update our model from $dto->toArray()). This PR will provide us this functionality