### PR TITLE
Enable object with MapTo properties to be cloned (Fix #272)

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -60,7 +60,7 @@ abstract class DataTransferObject
             }
 
             $mapToAttribute = $property->getAttributes(MapTo::class);
-            $name = count($mapToAttribute) && !$keepOriginalKeys ? $mapToAttribute[0]->newInstance()->name : $property->getName();
+            $name = count($mapToAttribute) && ! $keepOriginalKeys ? $mapToAttribute[0]->newInstance()->name : $property->getName();
 
             $data[$name] = $property->getValue($this);
         }

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -46,7 +46,7 @@ abstract class DataTransferObject
         );
     }
 
-    public function all(): array
+    public function all(bool $keepOriginalKeys = false): array
     {
         $data = [];
 
@@ -60,7 +60,7 @@ abstract class DataTransferObject
             }
 
             $mapToAttribute = $property->getAttributes(MapTo::class);
-            $name = count($mapToAttribute) ? $mapToAttribute[0]->newInstance()->name : $property->getName();
+            $name = count($mapToAttribute) && !$keepOriginalKeys ? $mapToAttribute[0]->newInstance()->name : $property->getName();
 
             $data[$name] = $property->getValue($this);
         }
@@ -88,15 +88,15 @@ abstract class DataTransferObject
 
     public function clone(...$args): static
     {
-        return new static(...array_merge($this->toArray(), $args));
+        return new static(...array_merge($this->toArray(keepOriginalKeys: true), $args));
     }
 
-    public function toArray(): array
+    public function toArray(bool $keepOriginalKeys = false): array
     {
         if (count($this->onlyKeys)) {
-            $array = Arr::only($this->all(), $this->onlyKeys);
+            $array = Arr::only($this->all($keepOriginalKeys), $this->onlyKeys);
         } else {
-            $array = Arr::except($this->all(), $this->exceptKeys);
+            $array = Arr::except($this->all($keepOriginalKeys), $this->exceptKeys);
         }
 
         $array = $this->parseArray($array);

--- a/tests/MapToTest.php
+++ b/tests/MapToTest.php
@@ -121,4 +121,21 @@ class MapToTest extends TestCase
         $this->assertEquals('Johnny Lawrence', $dtoArray['hero']);
         $this->assertFalse(Arr::exists($dtoArray, 'count'));
     }
+
+    /** @test */
+    public function mapped_property_is_cloned_properly(): void
+    {
+        $dto = new class (account: 1, villain: 'Johnny Lawrence') extends DataTransferObject {
+            public int $account;
+
+            #[MapTo('hero')]
+            public string $villain;
+        };
+
+        $clonedDto = $dto->clone(account: 2);
+        $clonedDtoArray = $clonedDto->toArray();
+
+        $this->assertEquals(2, $clonedDtoArray['account']);
+        $this->assertEquals('Johnny Lawrence', $clonedDtoArray['hero']);
+    }
 }


### PR DESCRIPTION
This PR adds a flag to ignore the MapTo attribute. 
In some cases, it could be useful to get the original keys instead of the mapped ones when  you export a data object to an array.
This is also the easiest way to fix the bug in issue #272 as we can just pass true for the $keepOrginalKeys flag and don't walk into any array merging issues. 

With the default value of false we also don't risk any breaking changes. If the flag is not passed, we get the same behavior as right now. 
