### PR TITLE
Add simple boolean caster

### DIFF
--- a/src/Casters/BooleanCaster.php
+++ b/src/Casters/BooleanCaster.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\DataTransferObject\Casters;
+
+use Spatie\DataTransferObject\Caster;
+
+class BooleanCaster implements Caster
+{
+    public function cast(mixed $value): bool
+    {
+        $acceptable = ['yes', 'on', '1', 1, true, 'true'];
+
+        return in_array($value, $acceptable, true);
+    }
+}

--- a/tests/Casters/BooleanCasterTest.php
+++ b/tests/Casters/BooleanCasterTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Spatie\DataTransferObject\Tests\Casters;
+
+use Spatie\DataTransferObject\Attributes\CastWith;
+use Spatie\DataTransferObject\Casters\BooleanCaster;
+use Spatie\DataTransferObject\DataTransferObject;
+use Spatie\DataTransferObject\Tests\TestCase;
+
+class BooleanCasterTest extends TestCase
+{
+    /** @test */
+    public function test_boolean_caster()
+    {
+        $this->assertTrue((new BooleanDTO(['active' => 'yes']))->active);
+        $this->assertTrue((new BooleanDTO(['active' => 'on']))->active);
+        $this->assertTrue((new BooleanDTO(['active' => '1']))->active);
+        $this->assertTrue((new BooleanDTO(['active' => 1]))->active);
+        $this->assertTrue((new BooleanDTO(['active' => true]))->active);
+        $this->assertTrue((new BooleanDTO(['active' => 'true']))->active);
+
+        $this->assertFalse((new BooleanDTO(['active' => 'no']))->active);
+        $this->assertFalse((new BooleanDTO(['active' => 'off']))->active);
+        $this->assertFalse((new BooleanDTO(['active' => '0']))->active);
+        $this->assertFalse((new BooleanDTO(['active' => 0]))->active);
+        $this->assertFalse((new BooleanDTO(['active' => false]))->active);
+        $this->assertFalse((new BooleanDTO(['active' => 'false']))->active);
+
+        $this->assertFalse((new BooleanDTO(['active' => 'unknown']))->active);
+    }
+}
+
+class BooleanDTO extends DataTransferObject
+{
+    #[CastWith(BooleanCaster::class)]
+    public bool $active;
+}


### PR DESCRIPTION
This PR adds a boolean caster with tests included.

The array of "truthy" booleans is sourced from Laravel's boolean validation: https://github.com/laravel/framework/blob/904bf5630a95ecf1d6623eb502ba7b751875faf4/src/Illuminate/Validation/Concerns/ValidatesAttributes.php#L422

Thanks!