### PR TITLE
Fallback to default value if json value is null

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -26,7 +26,7 @@ abstract class DataTransferObject
         $class = new DataTransferObjectClass($this);
 
         foreach ($class->getProperties() as $property) {
-            $property->setValue(Arr::get($args, $property->name, $property->getDefaultValue()));
+            $property->setValue(Arr::get($args, $property->name, $property->getDefaultValue()) ?? $property->getDefaultValue());
 
             $args = Arr::forget($args, $property->name);
         }

--- a/tests/MapFromTest.php
+++ b/tests/MapFromTest.php
@@ -102,4 +102,24 @@ class MapFromTest extends TestCase
         $this->assertFalse($dto->isPublic);
         $this->assertEquals(42, $dto->randomInt);
     }
+
+    /** @test */
+    public function mapped_from_works_with_default_values_if_json_value_is_null()
+    {
+        $data = [
+            'title' => 'Hello world',
+            'desc' => null,
+        ];
+
+        $dto = new class ($data) extends DataTransferObject {
+            public string $title;
+
+            #[MapFrom('desc')]
+            public string $description = 'Test Text';
+
+        };
+
+        $this->assertEquals('Hello world', $dto->title);
+        $this->assertEquals('Test Text', $dto->description);
+    }
 }


### PR DESCRIPTION
https://github.com/spatie/data-transfer-object/pull/251 broke an old behavior that I was depending on.

The change uses `Arr::get` which returns the default value only if the key does not exist in the array. But if the key exists *and* is `null`, then it will try to set the property to `null` instead of the expected default value.