### PR TITLE
Support nested arrays using "." notation in MapTo attributes

### DIFF
--- a/src/Arr.php
+++ b/src/Arr.php
@@ -95,4 +95,44 @@ class Arr
 
         return array_key_exists($key, $array);
     }
+
+    /**
+     * Set an array item to a given value using "dot" notation.
+     *
+     * If no key is given to the method, the entire array will be replaced.
+     *
+     * @param  array  $array
+     * @param  string|int|null  $key
+     * @param  mixed  $value
+     * @return array
+     */
+    public static function set(&$array, $key, $value)
+    {
+        if (is_null($key)) {
+            return $array = $value;
+        }
+
+        $keys = explode('.', $key);
+
+        foreach ($keys as $i => $key) {
+            if (count($keys) === 1) {
+                break;
+            }
+
+            unset($keys[$i]);
+
+            // If the key doesn't exist at this depth, we will just create an empty array
+            // to hold the next value, allowing us to create the arrays to hold final
+            // values at the correct depth. Then we'll keep digging into the array.
+            if (! isset($array[$key]) || ! is_array($array[$key])) {
+                $array[$key] = [];
+            }
+
+            $array = &$array[$key];
+        }
+
+        $array[array_shift($keys)] = $value;
+
+        return $array;
+    }
 }

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -62,7 +62,7 @@ abstract class DataTransferObject
             $mapToAttribute = $property->getAttributes(MapTo::class);
             $name = count($mapToAttribute) ? $mapToAttribute[0]->newInstance()->name : $property->getName();
 
-            $data[$name] = $property->getValue($this);
+            Arr::set($data, $name, $property->getValue($this));
         }
 
         return $data;

--- a/tests/MapToTest.php
+++ b/tests/MapToTest.php
@@ -121,4 +121,31 @@ class MapToTest extends TestCase
         $this->assertEquals('Johnny Lawrence', $dtoArray['hero']);
         $this->assertFalse(Arr::exists($dtoArray, 'count'));
     }
+
+    /** @test */
+    public function property_is_mapped_to_nested_array_if_splitted_by_a_dot()
+    {
+        $dto = new class (originalCount: 42, villain: 'Johnny Lawrence') extends DataTransferObject {
+            #[MapTo('count.testing')]
+            public int $originalCount;
+
+            #[MapTo('hero.villain')]
+            public string $villain;
+        };
+
+        $dtoArray = $dto->all();
+
+        $this->assertArrayNotHasKey('originalCount', $dtoArray);
+        $this->assertArrayNotHasKey('villain', $dtoArray);
+
+        $this->assertArrayHasKey('count', $dtoArray);
+        $this->assertIsArray($dtoArray['count']);
+        $this->assertArrayHasKey('testing', $dtoArray['count']);
+        $this->assertSame(42, $dtoArray['count']['testing']);
+
+        $this->assertArrayHasKey('hero', $dtoArray);
+        $this->assertIsArray($dtoArray['hero']);
+        $this->assertArrayHasKey('villain', $dtoArray['hero']);
+        $this->assertSame('Johnny Lawrence', $dtoArray['hero']['villain']);
+    }
 }


### PR DESCRIPTION
Hello Spatie.

## Use case
I am currently using this package to map over an external api response. This external api's uses a lot of nested array properties which I want to flatten down in the DTO properties.

## The problem
The mapping part is working great on nested arrays when using the `MapFrom` attribute but i find it a little bit strange that using the `MapTo` attribute doesn't take into account nested data structures using `.` notation in the same way as `MapFrom` currently does. 

Given this DTO definition:
```php
class DTO extends DataTransferObject {
    #[MapTo('count.testing')]
    #[MapFrom('count.testing')]
    public int $originalCount;

    #[MapTo('hero.villain')]
    #[MapFrom('hero.villain')]
    public string $villain;
};

new DTO(['count' => ['testing' => 'testing'], 'hero' => ['villain' => 'testing']]);
```

Currently when calling the `all` method on the DTO generates an array like this:
```php
[
    "count.testing" => 'testing',
    "hero.villain" => 'testing'
]
```
 But i expected it to be:

 ```php
[
    "count" => ['testing' => 'testing'],
    "hero" => ['villain', => 'testing'],
]
 ```
 
 This is what this pr is trying to change so we can effectively align the use of `MapFrom` attribute and `MapTo` attributes with each other.
 
 I am aware that this is probably a huge breaking change so it would probably require a major update.
 