### PR TITLE
Adding support for strict type checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,12 @@ new StrictDto(
 );
 ```
 
+### Type Coercion
+
+This package utilizes reflection to [set property values](https://www.php.net/manual/en/reflectionproperty.setvalue.php).
+Unfortunately, this means the any [strict_types declarations](https://www.php.net/manual/en/language.types.declarations.php#:~:text=of%20PHP%208.0.0.-,Strict%20typing%20%C2%B6,-By%20default%2C%20PHP) are ignored. As an alternative, Setting the Strict attribute will enforce strict type checks and prevent any coercion from occurring. 
+
+
 ## Helper functions
 
 There are also some helper functions provided for working with multiple properties at once.

--- a/src/Reflection/DataTransferObjectClass.php
+++ b/src/Reflection/DataTransferObjectClass.php
@@ -35,7 +35,8 @@ class DataTransferObjectClass
         return array_map(
             fn (ReflectionProperty $property) => new DataTransferObjectProperty(
                 $this->dataTransferObject,
-                $property
+                $property,
+                $this
             ),
             $publicProperties
         );

--- a/tests/Dummy/ComplexDtoWithAllTypes.php
+++ b/tests/Dummy/ComplexDtoWithAllTypes.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+namespace Spatie\DataTransferObject\Tests\Dummy;
+
+use Spatie\DataTransferObject\Attributes\Strict;
+use Spatie\DataTransferObject\DataTransferObject;
+
+#[Strict]
+class ComplexDtoWithAllTypes extends DataTransferObject
+{
+    public string $string;
+    public int $int;
+    public float $float;
+    public bool $bool;
+    public BasicDto $basicDto;
+}

--- a/tests/TypeCoercionTest.php
+++ b/tests/TypeCoercionTest.php
@@ -1,0 +1,92 @@
+<?php
+namespace Spatie\DataTransferObject\Tests;
+
+use Spatie\DataTransferObject\Tests\Dummy\ComplexDtoWithAllTypes;
+
+class TypeCoercionTest extends TestCase
+{
+    /** @test */
+    public function create_with_exact_types()
+    {
+        $dto = new ComplexDtoWithAllTypes(
+            string: "test",
+            int: 5,
+            bool: false,
+            float: 5.0,
+            basicDto: [
+                'name' => 'test'
+            ]
+        );
+
+        $this->assertEquals('test', $dto->string);
+    }
+    /** @test */
+    public function create_with_coercible_string()
+    {
+        try {
+            $dto = new ComplexDtoWithAllTypes(
+                string: 1,
+                int: 5,
+                bool: false,
+                float: 5.0,
+                basicDto: [
+                    'name' => 'test'
+                ]
+            );
+        } catch (\TypeError $typeError){
+            $this->assertStringContainsString("must be of type string", $typeError->getMessage());
+            $this->markTestSucceeded();
+        }
+    }
+    /** @test */
+    public function create_with_coercible_int()
+    {
+        try {
+            $dto = new ComplexDtoWithAllTypes(
+                string: "test",
+                int: "5",
+                bool: false,
+                float: 5.0,
+                basicDto: [
+                    'name' => 'test'
+                ]
+            );
+        } catch (\TypeError $typeError){
+            $this->assertStringContainsString("must be of type int", $typeError->getMessage());
+            $this->markTestSucceeded();
+        }
+    }
+    /** @test */
+    public function create_with_coercible_bool()
+    {
+        try {
+            $dto = new ComplexDtoWithAllTypes(
+                string: "test",
+                int: 5,
+                bool: "false",
+                float: 5.0,
+                basicDto: [
+                    'name' => 'test'
+                ]
+            );
+        } catch (\TypeError $typeError){
+            $this->assertStringContainsString("must be of type bool", $typeError->getMessage());
+            $this->markTestSucceeded();
+        }
+    }
+    /** @test */
+    public function create_with_coercible_float()
+    {
+        // floats coercion is allowed
+        $dto = new ComplexDtoWithAllTypes(
+            string: "test",
+            int: 5,
+            bool: false,
+            float: 5,
+            basicDto: [
+                'name' => 'test'
+            ]
+        );
+        $this->markTestSucceeded();
+    }
+}


### PR DESCRIPTION
We are utilizing dtos to enforce our API signatures.
So we have a preference to not allow for type coercion. Unfortunately since this is using setValue, our strict_types declarations are ignored.

This PR adds support for strict type checks utilizing the existing Strict attribute following the same rules enforced by native strict type declarations.

I saw an older issue about this that said it would be revisited, but haven't seen anything else related.
Let us know if there is any alternative