### PR TITLE
keep unknow properties for tracking even in non strict DTO s

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -17,6 +17,8 @@ abstract class DataTransferObject
 
     protected array $onlyKeys = [];
 
+    protected array $unknownProperties = [];
+
     public function __construct(...$args)
     {
         if (is_array($args[0] ?? null)) {
@@ -31,8 +33,12 @@ abstract class DataTransferObject
             $args = Arr::forget($args, $property->name);
         }
 
-        if ($class->isStrict() && count($args)) {
-            throw UnknownProperties::new(static::class, array_keys($args));
+        if (count($args)) {
+            if ($class->isStrict()) {
+                throw UnknownProperties::new(static::class, array_keys($args));
+            } else {
+                $this->unknownProperties = array_keys($args);
+            }
         }
 
         $class->validate();
@@ -44,6 +50,11 @@ abstract class DataTransferObject
             fn (mixed $parameters) => new static($parameters),
             $arrayOfParameters
         );
+    }
+
+    public function allUnknown(): array
+    {
+        return $this->unknownProperties;
     }
 
     public function all(): array

--- a/tests/StrictDtoTest.php
+++ b/tests/StrictDtoTest.php
@@ -20,6 +20,19 @@ class StrictDtoTest extends TestCase
     }
 
     /** @test */
+    public function non_strict_knows_unknown_properties()
+    {
+        $dto = new NonStrictDto(
+            name: 'name',
+            more: 23,
+            unknown: 'unknown'
+        );
+
+        $this->assertEqualsCanonicalizing(['more', 'unknown'], $dto->allUnknown());
+    }
+
+
+    /** @test */
     public function strict_test()
     {
         $this->expectException(UnknownProperties::class);


### PR DESCRIPTION
I'm unsure about the naming, but something like this would be pretty helpful. I would like to use strict DTOs to check and enforce my APIs, but then, the receiving code would break whenever a malformed DTO arrives. So I switch to non strict DTOs, but then, all messages arriving which contain some unspecified junk would go unnoticed.

The idea here with the PR is to keep that unknown attribute names for reporting purpose available. So I could log and warn about them in my stack, without actually bailing out on any bad message.