### PR TITLE
Ignoring uninitialized object properties

### DIFF
--- a/src/Attributes/OnlyInitialized.php
+++ b/src/Attributes/OnlyInitialized.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\DataTransferObject\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class OnlyInitialized
+{
+
+}

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -26,6 +26,10 @@ abstract class DataTransferObject
         $class = new DataTransferObjectClass($this);
 
         foreach ($class->getProperties() as $property) {
+            if ($class->isOnlyInitialized() && !Arr::exists($args, $property->name)) {
+                continue;
+            }
+
             $property->setValue(Arr::get($args, $property->name, $property->getDefaultValue()));
 
             $args = Arr::forget($args, $property->name);
@@ -55,7 +59,7 @@ abstract class DataTransferObject
         $properties = $class->getProperties(ReflectionProperty::IS_PUBLIC);
 
         foreach ($properties as $property) {
-            if ($property->isStatic()) {
+            if ($property->isStatic() || !$property->isInitialized($this)) {
                 continue;
             }
 

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -58,8 +58,10 @@ abstract class DataTransferObject
 
         $properties = $class->getProperties(ReflectionProperty::IS_PUBLIC);
 
+        $isOnlyInitialized = (new DataTransferObjectClass($this))->isOnlyInitialized();
+
         foreach ($properties as $property) {
-            if ($property->isStatic() || !$property->isInitialized($this)) {
+            if ($property->isStatic() || (!$property->isInitialized($this) && $isOnlyInitialized)) {
                 continue;
             }
 

--- a/src/Reflection/DataTransferObjectClass.php
+++ b/src/Reflection/DataTransferObjectClass.php
@@ -4,6 +4,7 @@ namespace Spatie\DataTransferObject\Reflection;
 
 use ReflectionClass;
 use ReflectionProperty;
+use Spatie\DataTransferObject\Attributes\OnlyInitialized;
 use Spatie\DataTransferObject\Attributes\Strict;
 use Spatie\DataTransferObject\DataTransferObject;
 use Spatie\DataTransferObject\Exceptions\ValidationException;
@@ -15,6 +16,8 @@ class DataTransferObjectClass
     private DataTransferObject $dataTransferObject;
 
     private bool $isStrict;
+
+    private bool $isOnlyInitialized;
 
     public function __construct(DataTransferObject $dataTransferObject)
     {
@@ -80,5 +83,23 @@ class DataTransferObjectClass
         }
 
         return $this->isStrict;
+    }
+
+    public function isOnlyInitialized(): bool
+    {
+        if (! isset($this->isOnlyInitialized)) {
+            $attribute = null;
+
+            $reflectionClass = $this->reflectionClass;
+            while ($attribute === null && $reflectionClass !== false) {
+                $attribute = $reflectionClass->getAttributes(OnlyInitialized::class)[0] ?? null;
+
+                $reflectionClass = $reflectionClass->getParentClass();
+            }
+
+            $this->isOnlyInitialized = $attribute !== null;
+        }
+
+        return $this->isOnlyInitialized;
     }
 }


### PR DESCRIPTION
This PR was created to address an issue with non-passable values in DTOs.

In the current implementation, properties whose values are not passed to the class constructor are set to their default values.

```php
<?php
use Spatie\DataTransferObject\DataTransferObject;

class UpdateArticleDTO extends DataTransferObject
{
    public ?string $title;
    public ?string $body;
}

$data = ['title' => 'Some title'];

(new UpdateArticleDTO($data))->toArray(); // ['title' => 'Some title', 'body' => null]
```

I suggest adding the ability to simply ignore these properties on getting by adding the `OnlyInitialized` attribute.

```php
<?php
use Spatie\DataTransferObject\Attributes\OnlyInitialized;
use Spatie\DataTransferObject\DataTransferObject;

#[OnlyInitialized]
class UpdateArticleDTO extends DataTransferObject
{
    public ?string $title;
    public ?string $body;
}

$data = ['title' => 'Some title'];

(new UpdateArticleDTO($data))->toArray(); // ['title' => 'Some title']
```

This can be useful for API requests to edit records in a database.
