### PR TITLE
Fix positional after named

### DIFF
--- a/src/Casters/DataTransferObjectCaster.php
+++ b/src/Casters/DataTransferObjectCaster.php
@@ -20,6 +20,6 @@ class DataTransferObjectCaster implements Caster
             }
         }
 
-        return new $this->classNames[0](...$value);
+        return new $this->classNames[0]($value);
     }
 }

--- a/tests/MapFromTest.php
+++ b/tests/MapFromTest.php
@@ -136,7 +136,8 @@ class MapFromTest extends TestCase
     }
 }
 
-class DTOInner extends DataTransferObject {
+class DTOInner extends DataTransferObject
+{
     public string $title;
 
     #[MapFrom('0')]


### PR DESCRIPTION
This pull request fixes a bug that causes properties mapped from a positional argument to fail after the argument array is unpacked into the casted child DTO. This fixes #298.