### PR TITLE
Add instanceof check to EnumCaster

### DIFF
--- a/src/Casters/EnumCaster.php
+++ b/src/Casters/EnumCaster.php
@@ -23,6 +23,10 @@ class EnumCaster implements Caster
             throw new LogicException("Caster [EnumCaster] may only be used to cast backed enums. Received [$this->enumType].");
         }
 
+        if (is_a($value, $this->enumType)) {
+            return $value;
+        }
+
         $castedValue = $this->enumType::tryFrom($value);
 
         if ($castedValue === null) {


### PR DESCRIPTION
A fix for when the instance of the enum itself is returned. The caster currently expects a string or int, but it's kinda weird that it doesn't except the enum itself.

![image](https://user-images.githubusercontent.com/1348606/198994372-00c19ad2-d3d0-41b7-a553-19bbb53773ab.png)
